### PR TITLE
Update config file example with new required parameter, bad_metrics_max_...

### DIFF
--- a/carbon-relay-ng.ini
+++ b/carbon-relay-ng.ini
@@ -6,6 +6,9 @@ http_addr = "0.0.0.0:8081"
 spool_dir = "spool"
 #one of critical error warning notice info debug
 log_level = "notice"
+# How long to keep track of invalid metrics seen
+# Useful time units are "s", "m", "h"
+bad_metrics_max_age = "24h"
 
 # put init commands here, in the same format as you'd use for the telnet interface
 init = [


### PR DESCRIPTION
Updated from b7ecf93 to 3ea244db5b7f905246f06cea2709bc445eda6e46 today and was unable to start my carbon-relay-ng instances. I found this message:

    [root@graphite-relay02 ~]# carbon-relay-ng /etc/carbon-relay-ng.ini
    16:01:37.474431 ▶ ERRO  could not parse badMetrics max age
    16:01:37.474461 ▶ ERRO  time: invalid duration 

Once I dug through the new commits I found the new parameter, ``bad_metrics_max_age``. This will add a default so people can get running out of the box.