### PR TITLE
regex / substring / prefix support for blacklist additions

### DIFF
--- a/admin_telnet.go
+++ b/admin_telnet.go
@@ -48,7 +48,7 @@ commands:
     help                                         show this menu
     view                                         view full current routing table
 
-    addBlack <substring>                         blacklist (drops the metric matching this as soon as it is received)
+    addBlack [prefix|sub|regex] <substring>      blacklist (drops the metric matching this as soon as it is received)
 
     addAgg <func> <regex> <fmt> <interval> <wait>  add a new aggregation rule.
              <func>:                             aggregation function to use

--- a/carbon-relay-ng.ini
+++ b/carbon-relay-ng.ini
@@ -13,7 +13,8 @@ bad_metrics_max_age = "24h"
 # put init commands here, in the same format as you'd use for the telnet interface
 # here's some examples:
 init = [
-     'addBlack collectd.localhost',  # ignore hosts that don't set their hostname properly.
+     'addBlack collectd.localhost',  # ignore hosts that don't set their hostname properly (implicit substring matrch).
+     'addBlack regex ^foo\..*\.cpu+', # ignore foo.<anything>.cpu.... (regex pattern match) 
      'addAgg sum ^stats\.timers\.(app|proxy|static)[0-9]+\.requests\.(.*) stats.timers._sum_$1.requests.$2 10 20',
      'addAgg avg ^stats\.timers\.(app|proxy|static)[0-9]+\.requests\.(.*) stats.timers._avg_$1.requests.$2 5 10',
      'addRoute sendAllMatch carbon-default  127.0.0.1:2005 spool=true pickle=false',


### PR DESCRIPTION
Hi. I'm a golang novice so this is probably incomplete -- in particular tests I am unfamiliar with.
We need to support regex blacklists to replace our existing carbon-relay setup (we push a *lot* of metrics)

This is a simple patch to include regex or prefix blacklists.