### PR TITLE
add 'target_type_is_counter' to the $dest template variable

### DIFF
--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -779,7 +779,7 @@
         "includeAll": true,
         "allFormat": "glob",
         "refresh": true,
-        "query": "service_is_carbon-relay-ng.instance_is_$instance.dest_is_*",
+        "query": "service_is_carbon-relay-ng.instance_is_$instance.target_type_is_counter.dest_is_*",
         "current": {},
         "regex": "/dest_is_(.*)/"
       }


### PR DESCRIPTION
In d4c4caa70e5b200965d821b9aee409af5e27832b some extra stats metric names were added, but the dashboard template variables didn't get updated, which was breaking rendering of all the but the 'All Incoming' graph in the grafana dashboard.  Adding 'target_type_is_counter' to the $dest variable to fix.