### PR TITLE
Consistent Hashing Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Future work aka what's missing
 
 * multi-node clustered high availability (open for discussion whether it's worth it)
 * pub-sub interface, maybe
-* consistent hashing across different endpoints, if it can be implemented in an elegant way.  (note that this would still be a hack and mostly aimed for legacy setups, [decent storage has redundancy and distribution built in properly ](http://dieter.plaetinck.be/on-graphite-whisper-and-influxdb.html).
 
 
 Releases & versions
@@ -89,7 +88,7 @@ The conditions are AND-ed.  Regexes are more resource intensive and hence should
 
   * sendAllMatch: send all metrics to all the defined endpoints (possibly, and commonly only 1 endpoint).
   * sendFirstMatch: send the metrics to the first endpoint that matches it.
-  * consistent hashing: the route is a CH pool (not implemented)
+  * consistentHashing: the algorithm is the same as Carbon's consistent hashing.
   * round robin: the route is a RR pool (not implemented)
 
 
@@ -177,6 +176,9 @@ commands:
                regex=<regex>                     only take in metrics that match this regex (expensive!)
              <dest>: <addr> <opts>
                <addr>                            a tcp endpoint. i.e. ip:port or hostname:port
+                                                 for consistentHashing routes, an instance identifier can also be present:
+                                                 hostname:port:instance
+                                                 The instance is used to disambiguate multiple endpoints on the same host, as the Carbon-compatible consistent hashing algorithm does not take the port into account.
                <opts>:
                    prefix=<str>                  only take in metrics that have this prefix
                    sub=<str>                     only take in metrics that match this substring

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Like carbon-relay from the graphite project, except it:
  * you can choose between plaintext or pickle output, per route.
  * can be restarted without dropping packets (needs testing)
  * performs validation on all incoming metrics (see below)
- 
+
 
 This makes it easy to fanout to other tools that feed in on the metrics.
 Or balance/split load, or provide redundancy, or partition the data, etc.
@@ -170,6 +170,7 @@ commands:
              <type>:
                sendAllMatch                      send metrics in the route to all destinations
                sendFirstMatch                    send metrics in the route to the first one that matches it
+               consistentHashing                 distribute metrics between destinations using a hash algorithm
              <opts>:
                prefix=<str>                      only take in metrics that have this prefix
                sub=<str>                         only take in metrics that match this substring

--- a/_third_party/github.com/bmizerany/assert/README.md
+++ b/_third_party/github.com/bmizerany/assert/README.md
@@ -1,0 +1,45 @@
+# Assert (c) Blake Mizerany and Keith Rarick -- MIT LICENCE
+
+## Assertions for Go tests
+
+## Install
+
+    $ go get github.com/bmizerany/assert
+
+## Use
+
+**point.go**
+
+    package point
+
+    type Point struct {
+        x, y int
+    }
+
+**point_test.go**
+
+
+    package point
+
+    import (
+        "testing"
+        "github.com/bmizerany/assert"
+    )
+
+    func TestAsserts(t *testing.T) {
+        p1 := Point{1, 1}
+        p2 := Point{2, 1}
+
+        assert.Equal(t, p1, p2)
+    }
+
+**output**
+    $ go test
+     --- FAIL: TestAsserts (0.00 seconds)
+	 assert.go:15: /Users/flavio.barbosa/dev/stewie/src/point_test.go:12
+         assert.go:24: ! X: 1 != 2
+	 FAIL
+
+## Docs
+
+    http://github.com/bmizerany/assert

--- a/_third_party/github.com/bmizerany/assert/assert.go
+++ b/_third_party/github.com/bmizerany/assert/assert.go
@@ -1,0 +1,77 @@
+package assert
+
+// Testing helpers for doozer.
+
+import (
+	"fmt"
+	"github.com/graphite-ng/carbon-relay-ng/_third_party/github.com/kr/pretty"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func assert(t *testing.T, result bool, f func(), cd int) {
+	if !result {
+		_, file, line, _ := runtime.Caller(cd + 1)
+		t.Errorf("%s:%d", file, line)
+		f()
+		t.FailNow()
+	}
+}
+
+func equal(t *testing.T, exp, got interface{}, cd int, args ...interface{}) {
+	fn := func() {
+		for _, desc := range pretty.Diff(exp, got) {
+			t.Error("!", desc)
+		}
+		if len(args) > 0 {
+			t.Error("!", " -", fmt.Sprint(args...))
+		}
+	}
+	result := reflect.DeepEqual(exp, got)
+	assert(t, result, fn, cd+1)
+}
+
+func tt(t *testing.T, result bool, cd int, args ...interface{}) {
+	fn := func() {
+		t.Errorf("!  Failure")
+		if len(args) > 0 {
+			t.Error("!", " -", fmt.Sprint(args...))
+		}
+	}
+	assert(t, result, fn, cd+1)
+}
+
+func T(t *testing.T, result bool, args ...interface{}) {
+	tt(t, result, 1, args...)
+}
+
+func Tf(t *testing.T, result bool, format string, args ...interface{}) {
+	tt(t, result, 1, fmt.Sprintf(format, args...))
+}
+
+func Equal(t *testing.T, exp, got interface{}, args ...interface{}) {
+	equal(t, exp, got, 1, args...)
+}
+
+func Equalf(t *testing.T, exp, got interface{}, format string, args ...interface{}) {
+	equal(t, exp, got, 1, fmt.Sprintf(format, args...))
+}
+
+func NotEqual(t *testing.T, exp, got interface{}, args ...interface{}) {
+	fn := func() {
+		t.Errorf("!  Unexpected: <%#v>", exp)
+		if len(args) > 0 {
+			t.Error("!", " -", fmt.Sprint(args...))
+		}
+	}
+	result := !reflect.DeepEqual(exp, got)
+	assert(t, result, fn, 1)
+}
+
+func Panic(t *testing.T, err interface{}, fn func()) {
+	defer func() {
+		equal(t, err, recover(), 3)
+	}()
+	fn()
+}

--- a/_third_party/github.com/bmizerany/assert/assert_test.go
+++ b/_third_party/github.com/bmizerany/assert/assert_test.go
@@ -1,0 +1,15 @@
+package assert
+
+import (
+	"testing"
+)
+
+func TestLineNumbers(t *testing.T) {
+	Equal(t, "foo", "foo", "msg!")
+	//Equal(t, "foo", "bar", "this should blow up")
+}
+
+func TestNotEqual(t *testing.T) {
+	NotEqual(t, "foo", "bar", "msg!")
+	//NotEqual(t, "foo", "foo", "this should blow up")
+}

--- a/_third_party/github.com/kisielk/og-rek/ogórek.go
+++ b/_third_party/github.com/kisielk/og-rek/ogórek.go
@@ -1,0 +1,806 @@
+// Package ogórek is a library for decoding Python's pickle format.
+//
+// ogórek is Polish for "pickle".
+package ogórek
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"math/big"
+	"strconv"
+)
+
+// Opcodes
+const (
+	opMark           byte = '(' // push special markobject on stack
+	opStop                = '.' // every pickle ends with STOP
+	opPop                 = '0' // discard topmost stack item
+	opPopMark             = '1' // discard stack top through topmost markobject
+	opDup                 = '2' // duplicate top stack item
+	opFloat               = 'F' // push float object; decimal string argument
+	opInt                 = 'I' // push integer or bool; decimal string argument
+	opBinint              = 'J' // push four-byte signed int
+	opBinint1             = 'K' // push 1-byte unsigned int
+	opLong                = 'L' // push long; decimal string argument
+	opBinint2             = 'M' // push 2-byte unsigned int
+	opNone                = 'N' // push None
+	opPersid              = 'P' // push persistent object; id is taken from string arg
+	opBinpersid           = 'Q' //  "       "         "  ;  "  "   "     "  stack
+	opReduce              = 'R' // apply callable to argtuple, both on stack
+	opString              = 'S' // push string; NL-terminated string argument
+	opBinstring           = 'T' // push string; counted binary string argument
+	opShortBinstring      = 'U' //  "     "   ;    "      "       "      " < 256 bytes
+	opUnicode             = 'V' // push Unicode string; raw-unicode-escaped"d argument
+	opBinunicode          = 'X' //   "     "       "  ; counted UTF-8 string argument
+	opAppend              = 'a' // append stack top to list below it
+	opBuild               = 'b' // call __setstate__ or __dict__.update()
+	opGlobal              = 'c' // push self.find_class(modname, name); 2 string args
+	opDict                = 'd' // build a dict from stack items
+	opEmptyDict           = '}' // push empty dict
+	opAppends             = 'e' // extend list on stack by topmost stack slice
+	opGet                 = 'g' // push item from memo on stack; index is string arg
+	opBinget              = 'h' //   "    "    "    "   "   "  ;   "    " 1-byte arg
+	opInst                = 'i' // build & push class instance
+	opLongBinget          = 'j' // push item from memo on stack; index is 4-byte arg
+	opList                = 'l' // build list from topmost stack items
+	opEmptyList           = ']' // push empty list
+	opObj                 = 'o' // build & push class instance
+	opPut                 = 'p' // store stack top in memo; index is string arg
+	opBinput              = 'q' //   "     "    "   "   " ;   "    " 1-byte arg
+	opLongBinput          = 'r' //   "     "    "   "   " ;   "    " 4-byte arg
+	opSetitem             = 's' // add key+value pair to dict
+	opTuple               = 't' // build tuple from topmost stack items
+	opEmptyTuple          = ')' // push empty tuple
+	opSetitems            = 'u' // modify dict by adding topmost key+value pairs
+	opBinfloat            = 'G' // push float; arg is 8-byte float encoding
+
+	opTrue  = "I01\n" // not an opcode; see INT docs in pickletools.py
+	opFalse = "I00\n" // not an opcode; see INT docs in pickletools.py
+
+	// Protocol 2
+
+	opProto    = '\x80' // identify pickle protocol
+	opNewobj   = '\x81' // build object by applying cls.__new__ to argtuple
+	opExt1     = '\x82' // push object from extension registry; 1-byte index
+	opExt2     = '\x83' // ditto, but 2-byte index
+	opExt4     = '\x84' // ditto, but 4-byte index
+	opTuple1   = '\x85' // build 1-tuple from stack top
+	opTuple2   = '\x86' // build 2-tuple from two topmost stack items
+	opTuple3   = '\x87' // build 3-tuple from three topmost stack items
+	opNewtrue  = '\x88' // push True
+	opNewfalse = '\x89' // push False
+	opLong1    = '\x8a' // push long from < 256 bytes
+	opLong4    = '\x8b' // push really big long
+)
+
+var errNotImplemented = errors.New("unimplemented opcode")
+var ErrInvalidPickleVersion = errors.New("invalid pickle version")
+var errNoMarker = errors.New("no marker in stack")
+
+type OpcodeError struct {
+	Key byte
+	Pos int
+}
+
+func (e OpcodeError) Error() string {
+	return fmt.Sprintf("Unknown opcode %d (%c) at position %d: %q", e.Key, e.Key, e.Pos, e.Key)
+}
+
+// special marker
+type mark struct{}
+
+// None is a representation of Python's None.
+type None struct{}
+
+// Decoder is a decoder for pickle streams.
+type Decoder struct {
+	r     *bufio.Reader
+	stack []interface{}
+	memo  map[string]interface{}
+}
+
+// NewDecoder constructs a new Decoder which will decode the pickle stream in r.
+func NewDecoder(r io.Reader) Decoder {
+	reader := bufio.NewReader(r)
+	return Decoder{reader, make([]interface{}, 0), make(map[string]interface{})}
+}
+
+// Decode decodes the pickle stream and returns the result or an error.
+func (d Decoder) Decode() (interface{}, error) {
+
+	insn := 0
+	for {
+		insn++
+		key, err := d.r.ReadByte()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+
+		switch key {
+		case opMark:
+			d.mark()
+		case opStop:
+			break
+		case opPop:
+			d.pop()
+		case opPopMark:
+			d.popMark()
+		case opDup:
+			d.dup()
+		case opFloat:
+			err = d.loadFloat()
+		case opInt:
+			err = d.loadInt()
+		case opBinint:
+			err = d.loadBinInt()
+		case opBinint1:
+			err = d.loadBinInt1()
+		case opLong:
+			err = d.loadLong()
+		case opBinint2:
+			err = d.loadBinInt2()
+		case opNone:
+			err = d.loadNone()
+		case opPersid:
+			err = d.loadPersid()
+		case opBinpersid:
+			err = d.loadBinPersid()
+		case opReduce:
+			err = d.reduce()
+		case opString:
+			err = d.loadString()
+		case opBinstring:
+			err = d.loadBinString()
+		case opShortBinstring:
+			err = d.loadShortBinString()
+		case opUnicode:
+			err = d.loadUnicode()
+		case opBinunicode:
+			err = d.loadBinUnicode()
+		case opAppend:
+			err = d.loadAppend()
+		case opBuild:
+			err = d.build()
+		case opGlobal:
+			err = d.global()
+		case opDict:
+			err = d.loadDict()
+		case opEmptyDict:
+			err = d.loadEmptyDict()
+		case opAppends:
+			err = d.loadAppends()
+		case opGet:
+			err = d.get()
+		case opBinget:
+			err = d.binGet()
+		case opInst:
+			err = d.inst()
+		case opLong1:
+			err = d.loadLong1()
+		case opNewfalse:
+			err = d.loadBool(false)
+		case opNewtrue:
+			err = d.loadBool(true)
+		case opLongBinget:
+			err = d.longBinGet()
+		case opList:
+			err = d.loadList()
+		case opEmptyList:
+			d.push([]interface{}{})
+		case opObj:
+			err = d.obj()
+		case opPut:
+			err = d.loadPut()
+		case opBinput:
+			err = d.binPut()
+		case opLongBinput:
+			err = d.longBinPut()
+		case opSetitem:
+			err = d.loadSetItem()
+		case opTuple:
+			err = d.loadTuple()
+		case opTuple1:
+			err = d.loadTuple1()
+		case opTuple2:
+			err = d.loadTuple2()
+		case opTuple3:
+			err = d.loadTuple3()
+		case opEmptyTuple:
+			d.push([]interface{}{})
+		case opSetitems:
+			err = d.loadSetItems()
+		case opBinfloat:
+			err = d.binFloat()
+		case opProto:
+			v, err := d.r.ReadByte()
+			if err == nil && v != 2 {
+				err = ErrInvalidPickleVersion
+			}
+
+		default:
+			return nil, OpcodeError{key, insn}
+		}
+
+		if err != nil {
+			if err == errNotImplemented {
+				return nil, OpcodeError{key, insn}
+			}
+			return nil, err
+		}
+	}
+	return d.pop(), nil
+}
+
+// Push a marker
+func (d *Decoder) mark() {
+	d.push(mark{})
+}
+
+// Return the position of the topmost marker
+func (d *Decoder) marker() (int, error) {
+	m := mark{}
+	var k int
+	for k = len(d.stack) - 1; d.stack[k] != m && k > 0; k-- {
+	}
+	if k >= 0 {
+		return k, nil
+	}
+	return 0, errNoMarker
+}
+
+// Append a new value
+func (d *Decoder) push(v interface{}) {
+	d.stack = append(d.stack, v)
+}
+
+// Pop a value
+func (d *Decoder) pop() interface{} {
+	ln := len(d.stack) - 1
+	v := d.stack[ln]
+	d.stack = d.stack[:ln]
+	return v
+}
+
+// Discard the stack through to the topmost marker
+func (d *Decoder) popMark() error {
+	return errNotImplemented
+}
+
+// Duplicate the top stack item
+func (d *Decoder) dup() {
+	d.stack = append(d.stack, d.stack[len(d.stack)-1])
+}
+
+// Push a float
+func (d *Decoder) loadFloat() error {
+	line, _, err := d.r.ReadLine()
+	if err != nil {
+		return err
+	}
+	v, err := strconv.ParseFloat(string(line), 64)
+	if err != nil {
+		return err
+	}
+	d.push(interface{}(v))
+	return nil
+}
+
+// Push an int
+func (d *Decoder) loadInt() error {
+	line, _, err := d.r.ReadLine()
+	if err != nil {
+		return err
+	}
+
+	var val interface{}
+
+	switch string(line) {
+	case opFalse[1:3]:
+		val = false
+	case opTrue[1:3]:
+		val = true
+	default:
+		i, err := strconv.ParseInt(string(line), 10, 64)
+		if err != nil {
+			return err
+		}
+		val = i
+	}
+
+	d.push(val)
+	return nil
+}
+
+// Push a four-byte signed int
+func (d *Decoder) loadBinInt() error {
+	var b [4]byte
+	_, err := io.ReadFull(d.r, b[:])
+	if err != nil {
+		return err
+	}
+	v := binary.LittleEndian.Uint32(b[:])
+	d.push(int64(v))
+	return nil
+}
+
+// Push a 1-byte unsigned int
+func (d *Decoder) loadBinInt1() error {
+	b, err := d.r.ReadByte()
+	if err != nil {
+		return err
+	}
+	d.push(int64(b))
+	return nil
+}
+
+// Push a long
+func (d *Decoder) loadLong() error {
+	line, _, err := d.r.ReadLine()
+	if err != nil {
+		return err
+	}
+	v := new(big.Int)
+	v.SetString(string(line[:len(line)-1]), 10)
+	d.push(v)
+	return nil
+}
+
+// Push a long1
+func (d *Decoder) loadLong1() error {
+	rawNum := []byte{}
+	b, err := d.r.ReadByte()
+	if err != nil {
+		return err
+	}
+	length, err := decodeLong(string(b))
+	if err != nil {
+		return err
+	}
+	for i := 0; int64(i) < length.Int64(); i++ {
+		b2, err := d.r.ReadByte()
+		if err != nil {
+			return err
+		}
+		rawNum = append(rawNum, b2)
+	}
+	decodedNum, err := decodeLong(string(rawNum))
+	d.push(decodedNum)
+	return nil
+}
+
+// Push a 2-byte unsigned int
+func (d *Decoder) loadBinInt2() error {
+	var b [2]byte
+	_, err := io.ReadFull(d.r, b[:])
+	if err != nil {
+		return err
+	}
+	v := binary.LittleEndian.Uint16(b[:])
+	d.push(int64(v))
+	return nil
+}
+
+// Push None
+func (d *Decoder) loadNone() error {
+	d.push(None{})
+	return nil
+}
+
+// Push a persistent object id
+func (d *Decoder) loadPersid() error {
+	return errNotImplemented
+}
+
+// Push a persistent object id from items on the stack
+func (d *Decoder) loadBinPersid() error {
+	return errNotImplemented
+}
+
+type Call struct {
+	Callable Class
+	Args     []interface{}
+}
+
+func (d *Decoder) reduce() error {
+	args := d.pop().([]interface{})
+	class := d.pop().(Class)
+	d.stack = append(d.stack, Call{Callable: class, Args: args})
+	return nil
+}
+
+func decodeStringEscape(b []byte) string {
+	// TODO
+	return string(b)
+}
+
+// Push a string
+func (d *Decoder) loadString() error {
+	line, _, err := d.r.ReadLine()
+	if err != nil {
+		return err
+	}
+
+	var delim byte
+	switch line[0] {
+	case '\'':
+		delim = '\''
+	case '"':
+		delim = '"'
+	default:
+		return fmt.Errorf("invalid string delimiter: %c", line[0])
+	}
+
+	if line[len(line)-1] != delim {
+		return fmt.Errorf("insecure string")
+	}
+
+	d.push(decodeStringEscape(line[1 : len(line)-1]))
+	return nil
+}
+
+func (d *Decoder) loadBinString() error {
+	var b [4]byte
+	_, err := io.ReadFull(d.r, b[:])
+	if err != nil {
+		return err
+	}
+	v := binary.LittleEndian.Uint32(b[:])
+	s := make([]byte, v)
+	_, err = io.ReadFull(d.r, s)
+	if err != nil {
+		return err
+	}
+	d.push(string(s))
+	return nil
+}
+
+func (d *Decoder) loadShortBinString() error {
+	b, err := d.r.ReadByte()
+	if err != nil {
+		return err
+	}
+
+	s := make([]byte, b)
+	_, err = io.ReadFull(d.r, s)
+	if err != nil {
+		return err
+	}
+	d.push(string(s))
+	return nil
+}
+
+func (d *Decoder) loadUnicode() error {
+	line, _, err := d.r.ReadLine()
+	if err != nil {
+		return err
+	}
+	sline := string(line)
+
+	buf := bytes.Buffer{}
+
+	for len(sline) >= 6 {
+		var r rune
+		var err error
+		r, _, sline, err = strconv.UnquoteChar(sline, '\'')
+		if err != nil {
+			return err
+		}
+		_, err = buf.WriteRune(r)
+		if err != nil {
+			return err
+		}
+	}
+	if len(sline) > 0 {
+		return fmt.Errorf("characters remaining after loadUnicode operation: %s", sline)
+	}
+
+	d.push(buf.String())
+	return nil
+}
+
+func (d *Decoder) loadBinUnicode() error {
+	var length int32
+	for i := 0; i < 4; i++ {
+		t, err := d.r.ReadByte()
+		if err != nil {
+			return err
+		}
+		length = length | (int32(t) << uint(8*i))
+	}
+	rawB := []byte{}
+	for z := 0; int32(z) < length; z++ {
+		n, err := d.r.ReadByte()
+		if err != nil {
+			return err
+		}
+		rawB = append(rawB, n)
+	}
+	d.push(string(rawB))
+	return nil
+}
+
+func (d *Decoder) loadAppend() error {
+	v := d.pop()
+	l := d.stack[len(d.stack)-1]
+	switch l.(type) {
+	case []interface{}:
+		l := l.([]interface{})
+		d.stack[len(d.stack)-1] = append(l, v)
+	default:
+		return fmt.Errorf("loadAppend expected a list, got %t", l)
+	}
+	return nil
+}
+
+func (d *Decoder) build() error {
+	return errNotImplemented
+}
+
+type Class struct {
+	Module, Name string
+}
+
+func (d *Decoder) global() error {
+	module, _, err := d.r.ReadLine()
+	if err != nil {
+		return err
+	}
+	name, _, err := d.r.ReadLine()
+	if err != nil {
+		return err
+	}
+	d.stack = append(d.stack, Class{Module: string(module), Name: string(name)})
+	return nil
+}
+
+func (d *Decoder) loadDict() error {
+	k, err := d.marker()
+	if err != nil {
+		return err
+	}
+
+	m := make(map[interface{}]interface{}, 0)
+	items := d.stack[k+1:]
+	for i := 0; i < len(items); i += 2 {
+		m[items[i]] = items[i+1]
+	}
+	d.stack = append(d.stack[:k], m)
+	return nil
+}
+
+func (d *Decoder) loadEmptyDict() error {
+	m := make(map[interface{}]interface{}, 0)
+	d.push(m)
+	return nil
+}
+
+func (d *Decoder) loadAppends() error {
+	k, err := d.marker()
+	if err != nil {
+		return err
+	}
+
+	l := d.stack[k-1]
+	switch l.(type) {
+	case []interface{}:
+		l := l.([]interface{})
+		for _, v := range d.stack[k+1 : len(d.stack)] {
+			l = append(l, v)
+		}
+		d.stack = append(d.stack[:k-1], l)
+	default:
+		return fmt.Errorf("loadAppends expected a list, got %t", l)
+	}
+	return nil
+}
+
+func (d *Decoder) get() error {
+	line, _, err := d.r.ReadLine()
+	if err != nil {
+		return err
+	}
+	d.push(d.memo[string(line)])
+	return nil
+}
+
+func (d *Decoder) binGet() error {
+	b, err := d.r.ReadByte()
+	if err != nil {
+		return err
+	}
+
+	d.push(d.memo[strconv.Itoa(int(b))])
+	return nil
+}
+
+func (d *Decoder) inst() error {
+	return errNotImplemented
+}
+
+func (d *Decoder) longBinGet() error {
+	var b [4]byte
+	_, err := io.ReadFull(d.r, b[:])
+	if err != nil {
+		return err
+	}
+	v := binary.LittleEndian.Uint32(b[:])
+	d.push(d.memo[strconv.Itoa(int(v))])
+	return nil
+}
+
+func (d *Decoder) loadBool(b bool) error {
+	d.push(b)
+	return nil
+}
+
+func (d *Decoder) loadList() error {
+	k, err := d.marker()
+	if err != nil {
+		return err
+	}
+
+	v := append([]interface{}{}, d.stack[k+1:]...)
+	d.stack = append(d.stack[:k], v)
+	return nil
+}
+
+func (d *Decoder) loadTuple() error {
+	k, err := d.marker()
+	if err != nil {
+		return err
+	}
+
+	v := append([]interface{}{}, d.stack[k+1:]...)
+	d.stack = append(d.stack[:k], v)
+	return nil
+}
+
+func (d *Decoder) loadTuple1() error {
+	k := len(d.stack) - 1
+	v := append([]interface{}{}, d.stack[k:]...)
+	d.stack = append(d.stack[:k], v)
+	return nil
+}
+
+func (d *Decoder) loadTuple2() error {
+	k := len(d.stack) - 2
+	v := append([]interface{}{}, d.stack[k:]...)
+	d.stack = append(d.stack[:k], v)
+	return nil
+}
+
+func (d *Decoder) loadTuple3() error {
+	k := len(d.stack) - 3
+	v := append([]interface{}{}, d.stack[k:]...)
+	d.stack = append(d.stack[:k], v)
+	return nil
+}
+
+func (d *Decoder) obj() error {
+	return errNotImplemented
+}
+
+func (d *Decoder) loadPut() error {
+	line, _, err := d.r.ReadLine()
+	if err != nil {
+		return err
+	}
+	d.memo[string(line)] = d.stack[len(d.stack)-1]
+	return nil
+}
+
+func (d *Decoder) binPut() error {
+	b, err := d.r.ReadByte()
+	if err != nil {
+		return err
+	}
+
+	d.memo[strconv.Itoa(int(b))] = d.stack[len(d.stack)-1]
+	return nil
+}
+
+func (d *Decoder) longBinPut() error {
+	var b [4]byte
+	_, err := io.ReadFull(d.r, b[:])
+	if err != nil {
+		return err
+	}
+	v := binary.LittleEndian.Uint32(b[:])
+	d.memo[strconv.Itoa(int(v))] = d.stack[len(d.stack)-1]
+	return nil
+}
+
+func (d *Decoder) loadSetItem() error {
+	v := d.pop()
+	k := d.pop()
+	m := d.stack[len(d.stack)-1]
+	switch m.(type) {
+	case map[interface{}]interface{}:
+		m := m.(map[interface{}]interface{})
+		m[k] = v
+	default:
+		return fmt.Errorf("loadSetItem expected a map, got %t", m)
+	}
+	return nil
+}
+
+func (d *Decoder) loadSetItems() error {
+	k, err := d.marker()
+	if err != nil {
+		return err
+	}
+
+	l := d.stack[k-1]
+	switch m := l.(type) {
+	case map[interface{}]interface{}:
+		for i := k + 1; i < len(d.stack); i += 2 {
+			m[d.stack[i]] = d.stack[i+1]
+		}
+		d.stack = append(d.stack[:k-1], m)
+	default:
+		return fmt.Errorf("loadSetItems expected a map, got %t", m)
+	}
+	return nil
+}
+
+func (d *Decoder) binFloat() error {
+	var b [8]byte
+	_, err := io.ReadFull(d.r, b[:])
+	if err != nil {
+		return err
+	}
+	u := binary.BigEndian.Uint64(b[:])
+	d.stack = append(d.stack, math.Float64frombits(u))
+	return nil
+}
+
+// decodeLong takes a byte array of 2's compliment little-endian binary words and converts them
+// to a big integer
+func decodeLong(data string) (*big.Int, error) {
+	decoded := big.NewInt(0)
+	var negative bool
+	switch x := len(data); {
+	case x < 1:
+		return decoded, nil
+	case x > 1:
+		if data[x-1] > 127 {
+			negative = true
+		}
+		for i := x - 1; i >= 0; i-- {
+			a := big.NewInt(int64(data[i]))
+			for n := i; n > 0; n-- {
+				a = a.Lsh(a, 8)
+			}
+			decoded = decoded.Add(a, decoded)
+		}
+	default:
+		if data[0] > 127 {
+			negative = true
+		}
+		decoded = big.NewInt(int64(data[0]))
+	}
+
+	if negative {
+		// Subtract 1 from the number
+		one := big.NewInt(1)
+		decoded.Sub(decoded, one)
+
+		// Flip the bits
+		bytes := decoded.Bytes()
+		for i := 0; i < len(bytes); i++ {
+			bytes[i] = ^bytes[i]
+		}
+		decoded.SetBytes(bytes)
+
+		// Mark as negative now conversion has been completed
+		decoded.Neg(decoded)
+	}
+	return decoded, nil
+}

--- a/_third_party/github.com/kisielk/og-rek/ogórek_test.go
+++ b/_third_party/github.com/kisielk/og-rek/ogórek_test.go
@@ -1,0 +1,174 @@
+package ogórek
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math/big"
+	"reflect"
+	"testing"
+)
+
+func bigInt(s string) *big.Int {
+	i := new(big.Int)
+	i.SetString(s, 10)
+	return i
+}
+
+func TestMarker(t *testing.T) {
+	buf := bytes.Buffer{}
+	dec := NewDecoder(&buf)
+	dec.mark()
+	k, err := dec.marker()
+	if err != nil {
+		t.Error(err)
+	}
+	if k != 0 {
+		t.Error("no marker found")
+	}
+}
+
+var graphitePickle1, _ = hex.DecodeString("80025d71017d710228550676616c75657371035d71042847407d90000000000047407f100000000000474080e0000000000047409764000000000047409c40000000000047409d88000000000047409f74000000000047409c74000000000047409cdc00000000004740a10000000000004740a0d800000000004740938800000000004740a00e00000000004740988800000000004e4e655505737461727471054a00d87a5255047374657071064a805101005503656e6471074a00f08f5255046e616d657108552d5a5a5a5a2e55555555555555552e43434343434343432e4d4d4d4d4d4d4d4d2e5858585858585858582e545454710975612e")
+var graphitePickle2, _ = hex.DecodeString("286c70300a286470310a53277374617274270a70320a49313338333738323430300a73532773746570270a70330a4938363430300a735327656e64270a70340a49313338353136343830300a73532776616c756573270a70350a286c70360a463437332e300a61463439372e300a61463534302e300a6146313439372e300a6146313830382e300a6146313839302e300a6146323031332e300a6146313832312e300a6146313834372e300a6146323137362e300a6146323135362e300a6146313235302e300a6146323035352e300a6146313537302e300a614e614e617353276e616d65270a70370a5327757365722e6c6f67696e2e617265612e6d616368696e652e6d65747269632e6d696e757465270a70380a73612e")
+var graphitePickel3, _ = hex.DecodeString("286c70310a286470320a5327696e74657276616c73270a70330a286c70340a7353276d65747269635f70617468270a70350a5327636172626f6e2e6167656e7473270a70360a73532769734c656166270a70370a4930300a7361286470380a67330a286c70390a7367350a5327636172626f6e2e61676772656761746f72270a7031300a7367370a4930300a736128647031310a67330a286c7031320a7367350a5327636172626f6e2e72656c617973270a7031330a7367370a4930300a73612e")
+
+func TestDecode(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected interface{}
+	}{
+		{"int", "I5\n.", int64(5)},
+		{"float", "F1.23\n.", float64(1.23)},
+		{"long", "L12321231232131231231L\n.", bigInt("12321231232131231231")},
+		{"None", "N.", None{}},
+		{"empty tuple", "(t.", []interface{}{}},
+		{"tuple of two ints", "(I1\nI2\ntp0\n.", []interface{}{int64(1), int64(2)}},
+		{"nested tuples", "((I1\nI2\ntp0\n(I3\nI4\ntp1\ntp2\n.",
+			[]interface{}{[]interface{}{int64(1), int64(2)}, []interface{}{int64(3), int64(4)}}},
+		{"tuple with top 1 items from stack", "I0\n\x85.", []interface{}{int64(0)}},
+		{"tuple with top 2 items from stack", "I0\nI1\n\x86.", []interface{}{int64(0), int64(1)}},
+		{"tuple with top 3 items from stack", "I0\nI1\nI2\n\x87.", []interface{}{int64(0), int64(1), int64(2)}},
+		{"empty list", "(lp0\n.", []interface{}{}},
+		{"list of numbers", "(lp0\nI1\naI2\naI3\naI4\na.", []interface{}{int64(1), int64(2), int64(3), int64(4)}},
+		{"string", "S'abc'\np0\n.", string("abc")},
+		{"unicode", "V\\u65e5\\u672c\\u8a9e\np0\n.", string("日本語")},
+		{"empty dict", "(dp0\n.", make(map[interface{}]interface{})},
+		{"dict with strings", "(dp0\nS'a'\np1\nS'1'\np2\nsS'b'\np3\nS'2'\np4\ns.", map[interface{}]interface{}{"a": "1", "b": "2"}},
+		{"GLOBAL and REDUCE opcodes", "cfoo\nbar\nS'bing'\n\x85R.", Call{Callable: Class{Module: "foo", Name: "bar"}, Args: []interface{}{"bing"}}},
+		{"LONG_BINPUT opcode", "(lr0000I17\na.", []interface{}{int64(17)}},
+		{"graphite message1", string(graphitePickle1), []interface{}{map[interface{}]interface{}{"values": []interface{}{float64(473), float64(497), float64(540), float64(1497), float64(1808), float64(1890), float64(2013), float64(1821), float64(1847), float64(2176), float64(2156), float64(1250), float64(2055), float64(1570), None{}, None{}}, "start": int64(1383782400), "step": int64(86400), "end": int64(1385164800), "name": "ZZZZ.UUUUUUUU.CCCCCCCC.MMMMMMMM.XXXXXXXXX.TTT"}}},
+		{"graphite message2", string(graphitePickle2), []interface{}{map[interface{}]interface{}{"values": []interface{}{float64(473), float64(497), float64(540), float64(1497), float64(1808), float64(1890), float64(2013), float64(1821), float64(1847), float64(2176), float64(2156), float64(1250), float64(2055), float64(1570), None{}, None{}}, "start": int64(1383782400), "step": int64(86400), "end": int64(1385164800), "name": "user.login.area.machine.metric.minute"}}},
+		{"graphite message3", string(graphitePickel3), []interface{}{map[interface{}]interface{}{"intervals": []interface{}{}, "metric_path": "carbon.agents", "isLeaf": false}, map[interface{}]interface{}{"intervals": []interface{}{}, "metric_path": "carbon.aggregator", "isLeaf": false}, map[interface{}]interface{}{"intervals": []interface{}{}, "metric_path": "carbon.relays", "isLeaf": false}}},
+	}
+	for _, test := range tests {
+		buf := bytes.NewBufferString(test.input)
+		dec := NewDecoder(buf)
+		v, err := dec.Decode()
+		if err != nil {
+			t.Error(err)
+		}
+
+		if !reflect.DeepEqual(v, test.expected) {
+			t.Errorf("%s: got\n%q\n expected\n%q", test.name, v, test.expected)
+		}
+	}
+}
+
+func TestZeroLengthData(t *testing.T) {
+	data := ""
+	output, err := decodeLong(data)
+	if err != nil {
+		t.Errorf("Error from decodeLong - %v\n", err)
+	}
+	if output.BitLen() > 0 {
+		t.Fail()
+	}
+}
+
+func TestValue1(t *testing.T) {
+	data := "\xff\x00"
+	output, err := decodeLong(data)
+	if err != nil {
+		t.Errorf("Error from decodeLong - %v\n", err)
+	}
+	target := big.NewInt(255)
+	if target.Cmp(output) != 0 {
+		t.Fail()
+	}
+}
+
+func TestValue2(t *testing.T) {
+	data := "\xff\x7f"
+	output, err := decodeLong(data)
+	if err != nil {
+		t.Errorf("Error from decodeLong - %v\n", err)
+	}
+	target := big.NewInt(32767)
+	if target.Cmp(output) != 0 {
+		t.Fail()
+	}
+}
+
+func TestValue3(t *testing.T) {
+	data := "\x00\xff"
+	output, err := decodeLong(data)
+	if err != nil {
+		t.Errorf("Error from decodeLong - %v\n", err)
+	}
+	target := big.NewInt(256)
+	target.Neg(target)
+	if target.Cmp(output) != 0 {
+		t.Logf("\nGot %v\nExpecting %v\n", output, target)
+		t.Fail()
+	}
+}
+
+func TestValue4(t *testing.T) {
+	data := "\x00\x80"
+	output, err := decodeLong(data)
+	if err != nil {
+		t.Errorf("Error from decodeLong - %v\n", err)
+	}
+	target := big.NewInt(32768)
+	target.Neg(target)
+	if target.Cmp(output) != 0 {
+		t.Logf("\nGot %v\nExpecting %v\n", output, target)
+		t.Fail()
+	}
+}
+
+func TestValue5(t *testing.T) {
+	data := "\x80"
+	output, err := decodeLong(data)
+	if err != nil {
+		t.Errorf("Error from decodeLong - %v\n", err)
+	}
+	target := big.NewInt(128)
+	target.Neg(target)
+	if target.Cmp(output) != 0 {
+		t.Logf("\nGot %v\nExpecting %v\n", output, target)
+		t.Fail()
+	}
+}
+
+func TestValue6(t *testing.T) {
+	data := "\x7f"
+	output, err := decodeLong(data)
+	if err != nil {
+		t.Errorf("Error from decodeLong - %v\n", err)
+	}
+	target := big.NewInt(127)
+	if target.Cmp(output) != 0 {
+		t.Fail()
+	}
+}
+
+func BenchmarkSpeed(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		data := "\x00\x80"
+		_, err := decodeLong(data)
+		if err != nil {
+			b.Errorf("Error from decodeLong - %v\n", err)
+		}
+	}
+}

--- a/_third_party/github.com/kr/pretty/License
+++ b/_third_party/github.com/kr/pretty/License
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright 2012 Keith Rarick
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/_third_party/github.com/kr/pretty/Readme
+++ b/_third_party/github.com/kr/pretty/Readme
@@ -1,0 +1,9 @@
+package pretty
+
+    import "github.com/kr/pretty"
+
+    Package pretty provides pretty-printing for Go values.
+
+Documentation
+
+    http://godoc.org/github.com/kr/pretty

--- a/_third_party/github.com/kr/pretty/diff.go
+++ b/_third_party/github.com/kr/pretty/diff.go
@@ -1,0 +1,158 @@
+package pretty
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+)
+
+type sbuf []string
+
+func (s *sbuf) Write(b []byte) (int, error) {
+	*s = append(*s, string(b))
+	return len(b), nil
+}
+
+// Diff returns a slice where each element describes
+// a difference between a and b.
+func Diff(a, b interface{}) (desc []string) {
+	Fdiff((*sbuf)(&desc), a, b)
+	return desc
+}
+
+// Fdiff writes to w a description of the differences between a and b.
+func Fdiff(w io.Writer, a, b interface{}) {
+	diffWriter{w: w}.diff(reflect.ValueOf(a), reflect.ValueOf(b))
+}
+
+type diffWriter struct {
+	w io.Writer
+	l string // label
+}
+
+func (w diffWriter) printf(f string, a ...interface{}) {
+	var l string
+	if w.l != "" {
+		l = w.l + ": "
+	}
+	fmt.Fprintf(w.w, l+f, a...)
+}
+
+func (w diffWriter) diff(av, bv reflect.Value) {
+	if !av.IsValid() && bv.IsValid() {
+		w.printf("nil != %#v", bv.Interface())
+		return
+	}
+	if av.IsValid() && !bv.IsValid() {
+		w.printf("%#v != nil", av.Interface())
+		return
+	}
+	if !av.IsValid() && !bv.IsValid() {
+		return
+	}
+
+	at := av.Type()
+	bt := bv.Type()
+	if at != bt {
+		w.printf("%v != %v", at, bt)
+		return
+	}
+
+	// numeric types, including bool
+	if at.Kind() < reflect.Array {
+		a, b := av.Interface(), bv.Interface()
+		if a != b {
+			w.printf("%#v != %#v", a, b)
+		}
+		return
+	}
+
+	switch at.Kind() {
+	case reflect.String:
+		a, b := av.Interface(), bv.Interface()
+		if a != b {
+			w.printf("%q != %q", a, b)
+		}
+	case reflect.Ptr:
+		switch {
+		case av.IsNil() && !bv.IsNil():
+			w.printf("nil != %v", bv.Interface())
+		case !av.IsNil() && bv.IsNil():
+			w.printf("%v != nil", av.Interface())
+		case !av.IsNil() && !bv.IsNil():
+			w.diff(av.Elem(), bv.Elem())
+		}
+	case reflect.Struct:
+		for i := 0; i < av.NumField(); i++ {
+			w.relabel(at.Field(i).Name).diff(av.Field(i), bv.Field(i))
+		}
+	case reflect.Slice:
+		lenA := av.Len()
+		lenB := bv.Len()
+		if lenA != lenB {
+			w.printf("%s[%d] != %s[%d]", av.Type(), lenA, bv.Type(), lenB)
+			break
+		}
+		for i := 0; i < lenA; i++ {
+			w.relabel(fmt.Sprintf("[%d]", i)).diff(av.Index(i), bv.Index(i))
+		}
+	case reflect.Map:
+		ak, both, bk := keyDiff(av.MapKeys(), bv.MapKeys())
+		for _, k := range ak {
+			w := w.relabel(fmt.Sprintf("[%#v]", k.Interface()))
+			w.printf("%q != (missing)", av.MapIndex(k))
+		}
+		for _, k := range both {
+			w := w.relabel(fmt.Sprintf("[%#v]", k.Interface()))
+			w.diff(av.MapIndex(k), bv.MapIndex(k))
+		}
+		for _, k := range bk {
+			w := w.relabel(fmt.Sprintf("[%#v]", k.Interface()))
+			w.printf("(missing) != %q", bv.MapIndex(k))
+		}
+	case reflect.Interface:
+		w.diff(reflect.ValueOf(av.Interface()), reflect.ValueOf(bv.Interface()))
+	default:
+		if !reflect.DeepEqual(av.Interface(), bv.Interface()) {
+			w.printf("%# v != %# v", Formatter(av.Interface()), Formatter(bv.Interface()))
+		}
+	}
+}
+
+func (d diffWriter) relabel(name string) (d1 diffWriter) {
+	d1 = d
+	if d.l != "" && name[0] != '[' {
+		d1.l += "."
+	}
+	d1.l += name
+	return d1
+}
+
+func keyDiff(a, b []reflect.Value) (ak, both, bk []reflect.Value) {
+	for _, av := range a {
+		inBoth := false
+		for _, bv := range b {
+			if reflect.DeepEqual(av.Interface(), bv.Interface()) {
+				inBoth = true
+				both = append(both, av)
+				break
+			}
+		}
+		if !inBoth {
+			ak = append(ak, av)
+		}
+	}
+	for _, bv := range b {
+		inBoth := false
+		for _, av := range a {
+			if reflect.DeepEqual(av.Interface(), bv.Interface()) {
+				inBoth = true
+				break
+			}
+		}
+		if !inBoth {
+			bk = append(bk, bv)
+		}
+	}
+	return
+}

--- a/_third_party/github.com/kr/pretty/diff_test.go
+++ b/_third_party/github.com/kr/pretty/diff_test.go
@@ -1,0 +1,74 @@
+package pretty
+
+import (
+	"testing"
+)
+
+type difftest struct {
+	a   interface{}
+	b   interface{}
+	exp []string
+}
+
+type S struct {
+	A int
+	S *S
+	I interface{}
+	C []int
+}
+
+var diffs = []difftest{
+	{a: nil, b: nil},
+	{a: S{A: 1}, b: S{A: 1}},
+
+	{0, "", []string{`int != string`}},
+	{0, 1, []string{`0 != 1`}},
+	{S{}, new(S), []string{`pretty.S != *pretty.S`}},
+	{"a", "b", []string{`"a" != "b"`}},
+	{S{}, S{A: 1}, []string{`A: 0 != 1`}},
+	{new(S), &S{A: 1}, []string{`A: 0 != 1`}},
+	{S{S: new(S)}, S{S: &S{A: 1}}, []string{`S.A: 0 != 1`}},
+	{S{}, S{I: 0}, []string{`I: nil != 0`}},
+	{S{I: 1}, S{I: "x"}, []string{`I: int != string`}},
+	{S{}, S{C: []int{1}}, []string{`C: []int[0] != []int[1]`}},
+	{S{C: []int{}}, S{C: []int{1}}, []string{`C: []int[0] != []int[1]`}},
+	{S{C: []int{1, 2, 3}}, S{C: []int{1, 2, 4}}, []string{`C[2]: 3 != 4`}},
+	{S{}, S{A: 1, S: new(S)}, []string{`A: 0 != 1`, `S: nil != &{0 <nil> <nil> []}`}},
+}
+
+func TestDiff(t *testing.T) {
+	for _, tt := range diffs {
+		got := Diff(tt.a, tt.b)
+		eq := len(got) == len(tt.exp)
+		if eq {
+			for i := range got {
+				eq = eq && got[i] == tt.exp[i]
+			}
+		}
+		if !eq {
+			t.Errorf("diffing % #v", tt.a)
+			t.Errorf("with    % #v", tt.b)
+			diffdiff(t, got, tt.exp)
+			continue
+		}
+	}
+}
+
+func diffdiff(t *testing.T, got, exp []string) {
+	minus(t, "unexpected:", got, exp)
+	minus(t, "missing:", exp, got)
+}
+
+func minus(t *testing.T, s string, a, b []string) {
+	var i, j int
+	for i = 0; i < len(a); i++ {
+		for j = 0; j < len(b); j++ {
+			if a[i] == b[j] {
+				break
+			}
+		}
+		if j == len(b) {
+			t.Error(s, a[i])
+		}
+	}
+}

--- a/_third_party/github.com/kr/pretty/example_test.go
+++ b/_third_party/github.com/kr/pretty/example_test.go
@@ -1,0 +1,20 @@
+package pretty_test
+
+import (
+	"fmt"
+	"github.com/graphite-ng/carbon-relay-ng/_third_party/github.com/kr/pretty"
+)
+
+func Example() {
+	type myType struct {
+		a, b int
+	}
+	var x = []myType{{1, 2}, {3, 4}, {5, 6}}
+	fmt.Printf("%# v", pretty.Formatter(x))
+	// output:
+	// []pretty_test.myType{
+	//     {a:1, b:2},
+	//     {a:3, b:4},
+	//     {a:5, b:6},
+	// }
+}

--- a/_third_party/github.com/kr/pretty/formatter.go
+++ b/_third_party/github.com/kr/pretty/formatter.go
@@ -1,0 +1,337 @@
+package pretty
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/graphite-ng/carbon-relay-ng/_third_party/github.com/kr/text"
+)
+
+const (
+	limit = 50
+)
+
+type formatter struct {
+	x     interface{}
+	force bool
+	quote bool
+}
+
+// Formatter makes a wrapper, f, that will format x as go source with line
+// breaks and tabs. Object f responds to the "%v" formatting verb when both the
+// "#" and " " (space) flags are set, for example:
+//
+//     fmt.Sprintf("%# v", Formatter(x))
+//
+// If one of these two flags is not set, or any other verb is used, f will
+// format x according to the usual rules of package fmt.
+// In particular, if x satisfies fmt.Formatter, then x.Format will be called.
+func Formatter(x interface{}) (f fmt.Formatter) {
+	return formatter{x: x, quote: true}
+}
+
+func (fo formatter) String() string {
+	return fmt.Sprint(fo.x) // unwrap it
+}
+
+func (fo formatter) passThrough(f fmt.State, c rune) {
+	s := "%"
+	for i := 0; i < 128; i++ {
+		if f.Flag(i) {
+			s += string(i)
+		}
+	}
+	if w, ok := f.Width(); ok {
+		s += fmt.Sprintf("%d", w)
+	}
+	if p, ok := f.Precision(); ok {
+		s += fmt.Sprintf(".%d", p)
+	}
+	s += string(c)
+	fmt.Fprintf(f, s, fo.x)
+}
+
+func (fo formatter) Format(f fmt.State, c rune) {
+	if fo.force || c == 'v' && f.Flag('#') && f.Flag(' ') {
+		w := tabwriter.NewWriter(f, 4, 4, 1, ' ', 0)
+		p := &printer{tw: w, Writer: w, visited: make(map[visit]int)}
+		p.printValue(reflect.ValueOf(fo.x), true, fo.quote)
+		w.Flush()
+		return
+	}
+	fo.passThrough(f, c)
+}
+
+type printer struct {
+	io.Writer
+	tw      *tabwriter.Writer
+	visited map[visit]int
+	depth   int
+}
+
+func (p *printer) indent() *printer {
+	q := *p
+	q.tw = tabwriter.NewWriter(p.Writer, 4, 4, 1, ' ', 0)
+	q.Writer = text.NewIndentWriter(q.tw, []byte{'\t'})
+	return &q
+}
+
+func (p *printer) printInline(v reflect.Value, x interface{}, showType bool) {
+	if showType {
+		io.WriteString(p, v.Type().String())
+		fmt.Fprintf(p, "(%#v)", x)
+	} else {
+		fmt.Fprintf(p, "%#v", x)
+	}
+}
+
+// printValue must keep track of already-printed pointer values to avoid
+// infinite recursion.
+type visit struct {
+	v   uintptr
+	typ reflect.Type
+}
+
+func (p *printer) printValue(v reflect.Value, showType, quote bool) {
+	if p.depth > 10 {
+		io.WriteString(p, "!%v(DEPTH EXCEEDED)")
+		return
+	}
+
+	switch v.Kind() {
+	case reflect.Bool:
+		p.printInline(v, v.Bool(), showType)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		p.printInline(v, v.Int(), showType)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		p.printInline(v, v.Uint(), showType)
+	case reflect.Float32, reflect.Float64:
+		p.printInline(v, v.Float(), showType)
+	case reflect.Complex64, reflect.Complex128:
+		fmt.Fprintf(p, "%#v", v.Complex())
+	case reflect.String:
+		p.fmtString(v.String(), quote)
+	case reflect.Map:
+		t := v.Type()
+		if showType {
+			io.WriteString(p, t.String())
+		}
+		writeByte(p, '{')
+		if nonzero(v) {
+			expand := !canInline(v.Type())
+			pp := p
+			if expand {
+				writeByte(p, '\n')
+				pp = p.indent()
+			}
+			keys := v.MapKeys()
+			for i := 0; i < v.Len(); i++ {
+				showTypeInStruct := true
+				k := keys[i]
+				mv := v.MapIndex(k)
+				pp.printValue(k, false, true)
+				writeByte(pp, ':')
+				if expand {
+					writeByte(pp, '\t')
+				}
+				showTypeInStruct = t.Elem().Kind() == reflect.Interface
+				pp.printValue(mv, showTypeInStruct, true)
+				if expand {
+					io.WriteString(pp, ",\n")
+				} else if i < v.Len()-1 {
+					io.WriteString(pp, ", ")
+				}
+			}
+			if expand {
+				pp.tw.Flush()
+			}
+		}
+		writeByte(p, '}')
+	case reflect.Struct:
+		t := v.Type()
+		if v.CanAddr() {
+			addr := v.UnsafeAddr()
+			vis := visit{addr, t}
+			if vd, ok := p.visited[vis]; ok && vd < p.depth {
+				p.fmtString(t.String()+"{(CYCLIC REFERENCE)}", false)
+				break // don't print v again
+			}
+			p.visited[vis] = p.depth
+		}
+
+		if showType {
+			io.WriteString(p, t.String())
+		}
+		writeByte(p, '{')
+		if nonzero(v) {
+			expand := !canInline(v.Type())
+			pp := p
+			if expand {
+				writeByte(p, '\n')
+				pp = p.indent()
+			}
+			for i := 0; i < v.NumField(); i++ {
+				showTypeInStruct := true
+				if f := t.Field(i); f.Name != "" {
+					io.WriteString(pp, f.Name)
+					writeByte(pp, ':')
+					if expand {
+						writeByte(pp, '\t')
+					}
+					showTypeInStruct = labelType(f.Type)
+				}
+				pp.printValue(getField(v, i), showTypeInStruct, true)
+				if expand {
+					io.WriteString(pp, ",\n")
+				} else if i < v.NumField()-1 {
+					io.WriteString(pp, ", ")
+				}
+			}
+			if expand {
+				pp.tw.Flush()
+			}
+		}
+		writeByte(p, '}')
+	case reflect.Interface:
+		switch e := v.Elem(); {
+		case e.Kind() == reflect.Invalid:
+			io.WriteString(p, "nil")
+		case e.IsValid():
+			pp := *p
+			pp.depth++
+			pp.printValue(e, showType, true)
+		default:
+			io.WriteString(p, v.Type().String())
+			io.WriteString(p, "(nil)")
+		}
+	case reflect.Array, reflect.Slice:
+		t := v.Type()
+		if showType {
+			io.WriteString(p, t.String())
+		}
+		if v.Kind() == reflect.Slice && v.IsNil() && showType {
+			io.WriteString(p, "(nil)")
+			break
+		}
+		if v.Kind() == reflect.Slice && v.IsNil() {
+			io.WriteString(p, "nil")
+			break
+		}
+		writeByte(p, '{')
+		expand := !canInline(v.Type())
+		pp := p
+		if expand {
+			writeByte(p, '\n')
+			pp = p.indent()
+		}
+		for i := 0; i < v.Len(); i++ {
+			showTypeInSlice := t.Elem().Kind() == reflect.Interface
+			pp.printValue(v.Index(i), showTypeInSlice, true)
+			if expand {
+				io.WriteString(pp, ",\n")
+			} else if i < v.Len()-1 {
+				io.WriteString(pp, ", ")
+			}
+		}
+		if expand {
+			pp.tw.Flush()
+		}
+		writeByte(p, '}')
+	case reflect.Ptr:
+		e := v.Elem()
+		if !e.IsValid() {
+			writeByte(p, '(')
+			io.WriteString(p, v.Type().String())
+			io.WriteString(p, ")(nil)")
+		} else {
+			pp := *p
+			pp.depth++
+			writeByte(pp, '&')
+			pp.printValue(e, true, true)
+		}
+	case reflect.Chan:
+		x := v.Pointer()
+		if showType {
+			writeByte(p, '(')
+			io.WriteString(p, v.Type().String())
+			fmt.Fprintf(p, ")(%#v)", x)
+		} else {
+			fmt.Fprintf(p, "%#v", x)
+		}
+	case reflect.Func:
+		io.WriteString(p, v.Type().String())
+		io.WriteString(p, " {...}")
+	case reflect.UnsafePointer:
+		p.printInline(v, v.Pointer(), showType)
+	case reflect.Invalid:
+		io.WriteString(p, "nil")
+	}
+}
+
+func canInline(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Map:
+		return !canExpand(t.Elem())
+	case reflect.Struct:
+		for i := 0; i < t.NumField(); i++ {
+			if canExpand(t.Field(i).Type) {
+				return false
+			}
+		}
+		return true
+	case reflect.Interface:
+		return false
+	case reflect.Array, reflect.Slice:
+		return !canExpand(t.Elem())
+	case reflect.Ptr:
+		return false
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		return false
+	}
+	return true
+}
+
+func canExpand(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Map, reflect.Struct,
+		reflect.Interface, reflect.Array, reflect.Slice,
+		reflect.Ptr:
+		return true
+	}
+	return false
+}
+
+func labelType(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Interface, reflect.Struct:
+		return true
+	}
+	return false
+}
+
+func (p *printer) fmtString(s string, quote bool) {
+	if quote {
+		s = strconv.Quote(s)
+	}
+	io.WriteString(p, s)
+}
+
+func tryDeepEqual(a, b interface{}) bool {
+	defer func() { recover() }()
+	return reflect.DeepEqual(a, b)
+}
+
+func writeByte(w io.Writer, b byte) {
+	w.Write([]byte{b})
+}
+
+func getField(v reflect.Value, i int) reflect.Value {
+	val := v.Field(i)
+	if val.Kind() == reflect.Interface && !val.IsNil() {
+		val = val.Elem()
+	}
+	return val
+}

--- a/_third_party/github.com/kr/pretty/formatter_test.go
+++ b/_third_party/github.com/kr/pretty/formatter_test.go
@@ -1,0 +1,261 @@
+package pretty
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"unsafe"
+)
+
+type test struct {
+	v interface{}
+	s string
+}
+
+type LongStructTypeName struct {
+	longFieldName      interface{}
+	otherLongFieldName interface{}
+}
+
+type SA struct {
+	t *T
+	v T
+}
+
+type T struct {
+	x, y int
+}
+
+type F int
+
+func (f F) Format(s fmt.State, c rune) {
+	fmt.Fprintf(s, "F(%d)", int(f))
+}
+
+var long = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+var gosyntax = []test{
+	{nil, `nil`},
+	{"", `""`},
+	{"a", `"a"`},
+	{1, "int(1)"},
+	{1.0, "float64(1)"},
+	{[]int(nil), "[]int(nil)"},
+	{[0]int{}, "[0]int{}"},
+	{complex(1, 0), "(1+0i)"},
+	//{make(chan int), "(chan int)(0x1234)"},
+	{unsafe.Pointer(uintptr(unsafe.Pointer(&long))), fmt.Sprintf("unsafe.Pointer(0x%02x)", uintptr(unsafe.Pointer(&long)))},
+	{func(int) {}, "func(int) {...}"},
+	{map[int]int{1: 1}, "map[int]int{1:1}"},
+	{int32(1), "int32(1)"},
+	{io.EOF, `&errors.errorString{s:"EOF"}`},
+	{[]string{"a"}, `[]string{"a"}`},
+	{
+		[]string{long},
+		`[]string{"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"}`,
+	},
+	{F(5), "pretty.F(5)"},
+	{
+		SA{&T{1, 2}, T{3, 4}},
+		`pretty.SA{
+    t:  &pretty.T{x:1, y:2},
+    v:  pretty.T{x:3, y:4},
+}`,
+	},
+	{
+		map[int][]byte{1: {}},
+		`map[int][]uint8{
+    1:  {},
+}`,
+	},
+	{
+		map[int]T{1: {}},
+		`map[int]pretty.T{
+    1:  {},
+}`,
+	},
+	{
+		long,
+		`"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"`,
+	},
+	{
+		LongStructTypeName{
+			longFieldName:      LongStructTypeName{},
+			otherLongFieldName: long,
+		},
+		`pretty.LongStructTypeName{
+    longFieldName:      pretty.LongStructTypeName{},
+    otherLongFieldName: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+}`,
+	},
+	{
+		&LongStructTypeName{
+			longFieldName:      &LongStructTypeName{},
+			otherLongFieldName: (*LongStructTypeName)(nil),
+		},
+		`&pretty.LongStructTypeName{
+    longFieldName:      &pretty.LongStructTypeName{},
+    otherLongFieldName: (*pretty.LongStructTypeName)(nil),
+}`,
+	},
+	{
+		[]LongStructTypeName{
+			{nil, nil},
+			{3, 3},
+			{long, nil},
+		},
+		`[]pretty.LongStructTypeName{
+    {},
+    {
+        longFieldName:      int(3),
+        otherLongFieldName: int(3),
+    },
+    {
+        longFieldName:      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+        otherLongFieldName: nil,
+    },
+}`,
+	},
+	{
+		[]interface{}{
+			LongStructTypeName{nil, nil},
+			[]byte{1, 2, 3},
+			T{3, 4},
+			LongStructTypeName{long, nil},
+		},
+		`[]interface {}{
+    pretty.LongStructTypeName{},
+    []uint8{0x1, 0x2, 0x3},
+    pretty.T{x:3, y:4},
+    pretty.LongStructTypeName{
+        longFieldName:      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+        otherLongFieldName: nil,
+    },
+}`,
+	},
+}
+
+func TestGoSyntax(t *testing.T) {
+	for _, tt := range gosyntax {
+		s := fmt.Sprintf("%# v", Formatter(tt.v))
+		if tt.s != s {
+			t.Errorf("expected %q", tt.s)
+			t.Errorf("got      %q", s)
+			t.Errorf("expraw\n%s", tt.s)
+			t.Errorf("gotraw\n%s", s)
+		}
+	}
+}
+
+type I struct {
+	i int
+	R interface{}
+}
+
+func (i *I) I() *I { return i.R.(*I) }
+
+func TestCycle(t *testing.T) {
+	type A struct{ *A }
+	v := &A{}
+	v.A = v
+
+	// panics from stack overflow without cycle detection
+	t.Logf("Example cycle:\n%# v", Formatter(v))
+
+	p := &A{}
+	s := fmt.Sprintf("%# v", Formatter([]*A{p, p}))
+	if strings.Contains(s, "CYCLIC") {
+		t.Errorf("Repeated address detected as cyclic reference:\n%s", s)
+	}
+
+	type R struct {
+		i int
+		*R
+	}
+	r := &R{
+		i: 1,
+		R: &R{
+			i: 2,
+			R: &R{
+				i: 3,
+			},
+		},
+	}
+	r.R.R.R = r
+	t.Logf("Example longer cycle:\n%# v", Formatter(r))
+
+	r = &R{
+		i: 1,
+		R: &R{
+			i: 2,
+			R: &R{
+				i: 3,
+				R: &R{
+					i: 4,
+					R: &R{
+						i: 5,
+						R: &R{
+							i: 6,
+							R: &R{
+								i: 7,
+								R: &R{
+									i: 8,
+									R: &R{
+										i: 9,
+										R: &R{
+											i: 10,
+											R: &R{
+												i: 11,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	// here be pirates
+	r.R.R.R.R.R.R.R.R.R.R.R = r
+	t.Logf("Example very long cycle:\n%# v", Formatter(r))
+
+	i := &I{
+		i: 1,
+		R: &I{
+			i: 2,
+			R: &I{
+				i: 3,
+				R: &I{
+					i: 4,
+					R: &I{
+						i: 5,
+						R: &I{
+							i: 6,
+							R: &I{
+								i: 7,
+								R: &I{
+									i: 8,
+									R: &I{
+										i: 9,
+										R: &I{
+											i: 10,
+											R: &I{
+												i: 11,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	iv := i.I().I().I().I().I().I().I().I().I().I()
+	*iv = *i
+	t.Logf("Example long interface cycle:\n%# v", Formatter(i))
+}

--- a/_third_party/github.com/kr/pretty/pretty.go
+++ b/_third_party/github.com/kr/pretty/pretty.go
@@ -1,0 +1,98 @@
+// Package pretty provides pretty-printing for Go values. This is
+// useful during debugging, to avoid wrapping long output lines in
+// the terminal.
+//
+// It provides a function, Formatter, that can be used with any
+// function that accepts a format string. It also provides
+// convenience wrappers for functions in packages fmt and log.
+package pretty
+
+import (
+	"fmt"
+	"io"
+	"log"
+)
+
+// Errorf is a convenience wrapper for fmt.Errorf.
+//
+// Calling Errorf(f, x, y) is equivalent to
+// fmt.Errorf(f, Formatter(x), Formatter(y)).
+func Errorf(format string, a ...interface{}) error {
+	return fmt.Errorf(format, wrap(a, false)...)
+}
+
+// Fprintf is a convenience wrapper for fmt.Fprintf.
+//
+// Calling Fprintf(w, f, x, y) is equivalent to
+// fmt.Fprintf(w, f, Formatter(x), Formatter(y)).
+func Fprintf(w io.Writer, format string, a ...interface{}) (n int, error error) {
+	return fmt.Fprintf(w, format, wrap(a, false)...)
+}
+
+// Log is a convenience wrapper for log.Printf.
+//
+// Calling Log(x, y) is equivalent to
+// log.Print(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Log(a ...interface{}) {
+	log.Print(wrap(a, true)...)
+}
+
+// Logf is a convenience wrapper for log.Printf.
+//
+// Calling Logf(f, x, y) is equivalent to
+// log.Printf(f, Formatter(x), Formatter(y)).
+func Logf(format string, a ...interface{}) {
+	log.Printf(format, wrap(a, false)...)
+}
+
+// Logln is a convenience wrapper for log.Printf.
+//
+// Calling Logln(x, y) is equivalent to
+// log.Println(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Logln(a ...interface{}) {
+	log.Println(wrap(a, true)...)
+}
+
+// Print pretty-prints its operands and writes to standard output.
+//
+// Calling Print(x, y) is equivalent to
+// fmt.Print(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Print(a ...interface{}) (n int, errno error) {
+	return fmt.Print(wrap(a, true)...)
+}
+
+// Printf is a convenience wrapper for fmt.Printf.
+//
+// Calling Printf(f, x, y) is equivalent to
+// fmt.Printf(f, Formatter(x), Formatter(y)).
+func Printf(format string, a ...interface{}) (n int, errno error) {
+	return fmt.Printf(format, wrap(a, false)...)
+}
+
+// Println pretty-prints its operands and writes to standard output.
+//
+// Calling Print(x, y) is equivalent to
+// fmt.Println(Formatter(x), Formatter(y)), but each operand is
+// formatted with "%# v".
+func Println(a ...interface{}) (n int, errno error) {
+	return fmt.Println(wrap(a, true)...)
+}
+
+// Sprintf is a convenience wrapper for fmt.Sprintf.
+//
+// Calling Sprintf(f, x, y) is equivalent to
+// fmt.Sprintf(f, Formatter(x), Formatter(y)).
+func Sprintf(format string, a ...interface{}) string {
+	return fmt.Sprintf(format, wrap(a, false)...)
+}
+
+func wrap(a []interface{}, force bool) []interface{} {
+	w := make([]interface{}, len(a))
+	for i, x := range a {
+		w[i] = formatter{x: x, force: force}
+	}
+	return w
+}

--- a/_third_party/github.com/kr/pretty/zero.go
+++ b/_third_party/github.com/kr/pretty/zero.go
@@ -1,0 +1,41 @@
+package pretty
+
+import (
+	"reflect"
+)
+
+func nonzero(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Bool:
+		return v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() != 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() != 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() != 0
+	case reflect.Complex64, reflect.Complex128:
+		return v.Complex() != complex(0, 0)
+	case reflect.String:
+		return v.String() != ""
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if nonzero(getField(v, i)) {
+				return true
+			}
+		}
+		return false
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if nonzero(v.Index(i)) {
+				return true
+			}
+		}
+		return false
+	case reflect.Map, reflect.Interface, reflect.Slice, reflect.Ptr, reflect.Chan, reflect.Func:
+		return !v.IsNil()
+	case reflect.UnsafePointer:
+		return v.Pointer() != 0
+	}
+	return true
+}

--- a/_third_party/github.com/kr/text/License
+++ b/_third_party/github.com/kr/text/License
@@ -1,0 +1,19 @@
+Copyright 2012 Keith Rarick
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/_third_party/github.com/kr/text/Readme
+++ b/_third_party/github.com/kr/text/Readme
@@ -1,0 +1,3 @@
+This is a Go package for manipulating paragraphs of text.
+
+See http://go.pkgdoc.org/github.com/kr/text for full documentation.

--- a/_third_party/github.com/kr/text/doc.go
+++ b/_third_party/github.com/kr/text/doc.go
@@ -1,0 +1,3 @@
+// Package text provides rudimentary functions for manipulating text in
+// paragraphs.
+package text

--- a/_third_party/github.com/kr/text/indent.go
+++ b/_third_party/github.com/kr/text/indent.go
@@ -1,0 +1,74 @@
+package text
+
+import (
+	"io"
+)
+
+// Indent inserts prefix at the beginning of each non-empty line of s. The
+// end-of-line marker is NL.
+func Indent(s, prefix string) string {
+	return string(IndentBytes([]byte(s), []byte(prefix)))
+}
+
+// IndentBytes inserts prefix at the beginning of each non-empty line of b.
+// The end-of-line marker is NL.
+func IndentBytes(b, prefix []byte) []byte {
+	var res []byte
+	bol := true
+	for _, c := range b {
+		if bol && c != '\n' {
+			res = append(res, prefix...)
+		}
+		res = append(res, c)
+		bol = c == '\n'
+	}
+	return res
+}
+
+// Writer indents each line of its input.
+type indentWriter struct {
+	w   io.Writer
+	bol bool
+	pre [][]byte
+	sel int
+	off int
+}
+
+// NewIndentWriter makes a new write filter that indents the input
+// lines. Each line is prefixed in order with the corresponding
+// element of pre. If there are more lines than elements, the last
+// element of pre is repeated for each subsequent line.
+func NewIndentWriter(w io.Writer, pre ...[]byte) io.Writer {
+	return &indentWriter{
+		w:   w,
+		pre: pre,
+		bol: true,
+	}
+}
+
+// The only errors returned are from the underlying indentWriter.
+func (w *indentWriter) Write(p []byte) (n int, err error) {
+	for _, c := range p {
+		if w.bol {
+			var i int
+			i, err = w.w.Write(w.pre[w.sel][w.off:])
+			w.off += i
+			if err != nil {
+				return n, err
+			}
+		}
+		_, err = w.w.Write([]byte{c})
+		if err != nil {
+			return n, err
+		}
+		n++
+		w.bol = c == '\n'
+		if w.bol {
+			w.off = 0
+			if w.sel < len(w.pre)-1 {
+				w.sel++
+			}
+		}
+	}
+	return n, nil
+}

--- a/_third_party/github.com/kr/text/indent_test.go
+++ b/_third_party/github.com/kr/text/indent_test.go
@@ -1,0 +1,119 @@
+package text
+
+import (
+	"bytes"
+	"testing"
+)
+
+type T struct {
+	inp, exp, pre string
+}
+
+var tests = []T{
+	{
+		"The quick brown fox\njumps over the lazy\ndog.\nBut not quickly.\n",
+		"xxxThe quick brown fox\nxxxjumps over the lazy\nxxxdog.\nxxxBut not quickly.\n",
+		"xxx",
+	},
+	{
+		"The quick brown fox\njumps over the lazy\ndog.\n\nBut not quickly.",
+		"xxxThe quick brown fox\nxxxjumps over the lazy\nxxxdog.\n\nxxxBut not quickly.",
+		"xxx",
+	},
+}
+
+func TestIndent(t *testing.T) {
+	for _, test := range tests {
+		got := Indent(test.inp, test.pre)
+		if got != test.exp {
+			t.Errorf("mismatch %q != %q", got, test.exp)
+		}
+	}
+}
+
+type IndentWriterTest struct {
+	inp, exp string
+	pre      []string
+}
+
+var ts = []IndentWriterTest{
+	{
+		`
+The quick brown fox
+jumps over the lazy
+dog.
+But not quickly.
+`[1:],
+		`
+xxxThe quick brown fox
+xxxjumps over the lazy
+xxxdog.
+xxxBut not quickly.
+`[1:],
+		[]string{"xxx"},
+	},
+	{
+		`
+The quick brown fox
+jumps over the lazy
+dog.
+But not quickly.
+`[1:],
+		`
+xxaThe quick brown fox
+xxxjumps over the lazy
+xxxdog.
+xxxBut not quickly.
+`[1:],
+		[]string{"xxa", "xxx"},
+	},
+	{
+		`
+The quick brown fox
+jumps over the lazy
+dog.
+But not quickly.
+`[1:],
+		`
+xxaThe quick brown fox
+xxbjumps over the lazy
+xxcdog.
+xxxBut not quickly.
+`[1:],
+		[]string{"xxa", "xxb", "xxc", "xxx"},
+	},
+	{
+		`
+The quick brown fox
+jumps over the lazy
+dog.
+
+But not quickly.`[1:],
+		`
+xxaThe quick brown fox
+xxxjumps over the lazy
+xxxdog.
+xxx
+xxxBut not quickly.`[1:],
+		[]string{"xxa", "xxx"},
+	},
+}
+
+func TestIndentWriter(t *testing.T) {
+	for _, test := range ts {
+		b := new(bytes.Buffer)
+		pre := make([][]byte, len(test.pre))
+		for i := range test.pre {
+			pre[i] = []byte(test.pre[i])
+		}
+		w := NewIndentWriter(b, pre...)
+		if _, err := w.Write([]byte(test.inp)); err != nil {
+			t.Error(err)
+		}
+		if got := b.String(); got != test.exp {
+			t.Errorf("mismatch %q != %q", got, test.exp)
+			t.Log(got)
+			t.Log(test.exp)
+		}
+	}
+}

--- a/_third_party/github.com/kr/text/wrap.go
+++ b/_third_party/github.com/kr/text/wrap.go
@@ -1,0 +1,86 @@
+package text
+
+import (
+	"bytes"
+	"math"
+)
+
+var (
+	nl = []byte{'\n'}
+	sp = []byte{' '}
+)
+
+const defaultPenalty = 1e5
+
+// Wrap wraps s into a paragraph of lines of length lim, with minimal
+// raggedness.
+func Wrap(s string, lim int) string {
+	return string(WrapBytes([]byte(s), lim))
+}
+
+// WrapBytes wraps b into a paragraph of lines of length lim, with minimal
+// raggedness.
+func WrapBytes(b []byte, lim int) []byte {
+	words := bytes.Split(bytes.Replace(bytes.TrimSpace(b), nl, sp, -1), sp)
+	var lines [][]byte
+	for _, line := range WrapWords(words, 1, lim, defaultPenalty) {
+		lines = append(lines, bytes.Join(line, sp))
+	}
+	return bytes.Join(lines, nl)
+}
+
+// WrapWords is the low-level line-breaking algorithm, useful if you need more
+// control over the details of the text wrapping process. For most uses, either
+// Wrap or WrapBytes will be sufficient and more convenient.
+//
+// WrapWords splits a list of words into lines with minimal "raggedness",
+// treating each byte as one unit, accounting for spc units between adjacent
+// words on each line, and attempting to limit lines to lim units. Raggedness
+// is the total error over all lines, where error is the square of the
+// difference of the length of the line and lim. Too-long lines (which only
+// happen when a single word is longer than lim units) have pen penalty units
+// added to the error.
+func WrapWords(words [][]byte, spc, lim, pen int) [][][]byte {
+	n := len(words)
+
+	length := make([][]int, n)
+	for i := 0; i < n; i++ {
+		length[i] = make([]int, n)
+		length[i][i] = len(words[i])
+		for j := i + 1; j < n; j++ {
+			length[i][j] = length[i][j-1] + spc + len(words[j])
+		}
+	}
+
+	nbrk := make([]int, n)
+	cost := make([]int, n)
+	for i := range cost {
+		cost[i] = math.MaxInt32
+	}
+	for i := n - 1; i >= 0; i-- {
+		if length[i][n-1] <= lim {
+			cost[i] = 0
+			nbrk[i] = n
+		} else {
+			for j := i + 1; j < n; j++ {
+				d := lim - length[i][j-1]
+				c := d*d + cost[j]
+				if length[i][j-1] > lim {
+					c += pen // too-long lines get a worse penalty
+				}
+				if c < cost[i] {
+					cost[i] = c
+					nbrk[i] = j
+				}
+			}
+		}
+	}
+
+	var lines [][][]byte
+	i := 0
+	for i < n {
+		lines = append(lines, words[i:nbrk[i]])
+		i = nbrk[i]
+	}
+	return lines
+}

--- a/_third_party/github.com/kr/text/wrap_test.go
+++ b/_third_party/github.com/kr/text/wrap_test.go
@@ -1,0 +1,44 @@
+package text
+
+import (
+	"bytes"
+	"testing"
+)
+
+var text = "The quick brown fox jumps over the lazy dog."
+
+func TestWrap(t *testing.T) {
+	exp := [][]string{
+		{"The", "quick", "brown", "fox"},
+		{"jumps", "over", "the", "lazy", "dog."},
+	}
+	words := bytes.Split([]byte(text), sp)
+	got := WrapWords(words, 1, 24, defaultPenalty)
+	if len(exp) != len(got) {
+		t.Fail()
+	}
+	for i := range exp {
+		if len(exp[i]) != len(got[i]) {
+			t.Fail()
+		}
+		for j := range exp[i] {
+			if exp[i][j] != string(got[i][j]) {
+				t.Fatal(i, exp[i][j], got[i][j])
+			}
+		}
+	}
+}
+
+func TestWrapNarrow(t *testing.T) {
+	exp := "The\nquick\nbrown\nfox\njumps\nover\nthe\nlazy\ndog."
+	if Wrap(text, 5) != exp {
+		t.Fail()
+	}
+}
+
+func TestWrapOneLine(t *testing.T) {
+	exp := "The quick brown fox jumps over the lazy dog."
+	if Wrap(text, 500) != exp {
+		t.Fail()
+	}
+}

--- a/admin_http_assets/app.js
+++ b/admin_http_assets/app.js
@@ -7,15 +7,15 @@ app.controller("MainCtl", ["$scope", "$resource", "$modal", function($scope, $re
   var Aggregator = $resource("/aggregators/:index");
   var Route = $resource("/routes/:key", {key: '@key'}, {});
   var Destination = $resource("/routes/:key/destinations/:index");
-  
 
-  $scope.validAddress = /^[^:]+\:[0-9]+$/;
-  $scope.validRouteType = /^send(All|First)Match/
+
+  $scope.validAddress = /^[^:]+\:[0-9]+(:[^:]+)?$/;
+  $scope.validRouteType = /^(send(All|First)Match)|(consistentHashing)/
   $scope.validRegex = (function() {
       return {
           test: function(value) {
               var isValid = true;
-              try { 
+              try {
                 new RegExp(value);
               } catch(e) {
                 isValid = false;

--- a/admin_http_assets/index.html
+++ b/admin_http_assets/index.html
@@ -184,7 +184,7 @@
                   <td class="form-group has-feedback">
                     <input ng-model="newRoute.Type" name="Type" class="form-control" placeholder="sendAllMatch" required ng-pattern="validRouteType">
                     <div ng-show="routeForm.Type.$invalid">
-                      <span ng-show="routeForm.Type.$error.pattern">Expected sendAllMatch or sendFirstMatch</span>
+                      <span ng-show="routeForm.Type.$error.pattern">Expected sendAllMatch, sendFirstMatch, or consistentHashing</span>
                     </div>
                   </td>
                   <td class="form-group has-feedback">

--- a/admin_telnet.go
+++ b/admin_telnet.go
@@ -64,6 +64,7 @@ commands:
              <type>:
                sendAllMatch                      send metrics in the route to all destinations
                sendFirstMatch                    send metrics in the route to the first one that matches it
+               consistentHashing                 distribute metrics between destinations using a hash algorithm
              <opts>:
                prefix=<str>                      only take in metrics that have this prefix
                sub=<str>                         only take in metrics that match this substring

--- a/carbon-relay-ng_test.go
+++ b/carbon-relay-ng_test.go
@@ -129,9 +129,12 @@ func test3RangesWith2EndpointAndSpoolInMiddle(t *testing.T, reconnMs, flushMs in
 	table := NewTableOrFatal(t, spoolDir, cmd)
 	fmt.Println(table.Print())
 	log.Notice("waiting for both connections to establish")
-	naUUU.AllowBG(50*time.Millisecond, &tEWaits)
-	naUDU.AllowBG(50*time.Millisecond, &tEWaits)
+	naUUU.AllowBG(100*time.Millisecond, &tEWaits)
+	naUDU.AllowBG(100*time.Millisecond, &tEWaits)
 	tEWaits.Wait()
+	// Give some time for unspooled destination to be marked online.
+	// Otherwise, the first metric is sometimes dropped.
+	time.Sleep(5 * time.Millisecond)
 	log.Notice("sending first batch of metrics to table")
 	nsUUU := tUUU.conditionNumSeen(1000)
 	nsUDU := tUDU.conditionNumSeen(1000)
@@ -245,9 +248,12 @@ func test2Endpoints(t *testing.T, reconnMs, flushMs int, dp *dummyPackets) {
 	table := NewTableOrFatal(t, spoolDir, cmd)
 	fmt.Println(table.Print())
 	log.Notice("waiting for both connections to establish")
-	na1.AllowBG(50*time.Millisecond, &tEWaits)
-	na2.AllowBG(50*time.Millisecond, &tEWaits)
+	na1.AllowBG(100*time.Millisecond, &tEWaits)
+	na2.AllowBG(100*time.Millisecond, &tEWaits)
 	tEWaits.Wait()
+	// Give some time for unspooled destination to be marked online.
+	// Otherwise, the first metric is sometimes dropped.
+	time.Sleep(5 * time.Millisecond)
 	log.Notice("sending metrics to table")
 	ns1 := t1.conditionNumSeen(dp.amount)
 	ns2 := t2.conditionNumSeen(dp.amount)

--- a/consistent_hashing.go
+++ b/consistent_hashing.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/binary"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type hashRingEntry struct {
+	Position         uint16
+	Hostname         string
+	Instance         string
+	DestinationIndex int
+}
+
+// hashRing represents the ring of elements and implements sort.Interface
+// comparing `Position`, `Hostname`, and `Instance`, in that order.
+type hashRing []hashRingEntry
+
+// Len, Swap, and Less make up sort.Interface.
+func (r hashRing) Len() int {
+	return len(r)
+}
+func (r hashRing) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+func (r hashRing) Less(i, j int) bool {
+	return r[i].Position < r[j].Position ||
+		(r[i].Position == r[j].Position && r[i].Hostname < r[j].Hostname) ||
+		(r[i].Position == r[j].Position && r[i].Hostname == r[j].Hostname && r[i].Instance < r[j].Instance)
+}
+
+type ConsistentHasher struct {
+	Ring         hashRing
+	destinations []*Destination
+	replicaCount int
+}
+
+func computeRingPosition(key []byte) uint16 {
+	var Position uint16
+	hash := md5.Sum(key)
+	buf := bytes.NewReader(hash[0:2])
+	binary.Read(buf, binary.BigEndian, &Position)
+	return Position
+}
+
+func NewConsistentHasher(destinations []*Destination) ConsistentHasher {
+	return NewConsistentHasherReplicaCount(destinations, 100)
+}
+
+func NewConsistentHasherReplicaCount(destinations []*Destination, replicaCount int) ConsistentHasher {
+	hashRing := ConsistentHasher{replicaCount: replicaCount}
+	for _, d := range destinations {
+		hashRing.AddDestination(d)
+	}
+	return hashRing
+}
+
+func (h *ConsistentHasher) AddDestination(d *Destination) {
+	newDestinationIndex := len(h.destinations)
+	h.destinations = append(h.destinations, d)
+	newRingEntries := make(hashRing, h.replicaCount)
+	for i := 0; i < h.replicaCount; i++ {
+		var keyBuf bytes.Buffer
+		// The part of the key prior to the ':' is actually the Python
+		// string representation of the tuple (server, instance) in the
+		// original Carbon code. Note that the server component excludes
+		// the port.
+		server := strings.Split(d.Addr, ":")
+		keyBuf.WriteString("('")
+		keyBuf.WriteString(server[0])
+		keyBuf.WriteString("', ")
+		if d.Instance != "" {
+			keyBuf.WriteString("'")
+			keyBuf.WriteString(d.Instance)
+			keyBuf.WriteString("'")
+		} else {
+			keyBuf.WriteString("None")
+		}
+		keyBuf.WriteString(")")
+		keyBuf.WriteString(":")
+		keyBuf.WriteString(strconv.Itoa(i))
+		position := computeRingPosition(keyBuf.Bytes())
+		newRingEntries[i].Position = position
+		newRingEntries[i].Hostname = server[0]
+		newRingEntries[i].Instance = d.Instance
+		newRingEntries[i].DestinationIndex = newDestinationIndex
+	}
+	h.Ring = append(h.Ring, newRingEntries...)
+	sort.Sort(h.Ring)
+}
+
+// GetDestinationIndex returns the index of the destination corresponding
+// to the provided key.
+func (h *ConsistentHasher) GetDestinationIndex(key []byte) int {
+	position := computeRingPosition(key)
+	// Find the index where we would insert a server entry with the same
+	// position field as the position for the specified key.
+	// This is equivalent to bisect_left in the Python implementation.
+	index := sort.Search(len(h.Ring), func(i int) bool { return h.Ring[i].Position >= position }) % len(h.Ring)
+	return h.Ring[index].DestinationIndex
+}

--- a/consistent_hashing_test.go
+++ b/consistent_hashing_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/graphite-ng/carbon-relay-ng/_third_party/github.com/bmizerany/assert"
+)
+
+func TestConsistentHashingComputeRingPosition(t *testing.T) {
+	assert.Equal(t, uint16(54437), computeRingPosition([]byte("a.b.c.d")))
+	assert.Equal(t, uint16(54301), computeRingPosition([]byte("")))
+}
+
+func TestConsistentHashingDestinations(t *testing.T) {
+	initialDestinations := []*Destination{
+		&Destination{Addr: "10.0.0.1"},
+		&Destination{Addr: "127.0.0.1:2003", Instance: "a"},
+		&Destination{Addr: "127.0.0.1:2004", Instance: "b"}}
+	hasher := NewConsistentHasherReplicaCount(initialDestinations, 2)
+	expectedHashRing := hashRing{
+		hashRingEntry{Position: uint16(7885), Hostname: "127.0.0.1", Instance: "a", DestinationIndex: 1},
+		hashRingEntry{Position: uint16(10461), Hostname: "127.0.0.1", Instance: "b", DestinationIndex: 2},
+		hashRingEntry{Position: uint16(24043), Hostname: "127.0.0.1", Instance: "a", DestinationIndex: 1},
+		hashRingEntry{Position: uint16(35540), Hostname: "10.0.0.1", DestinationIndex: 0},
+		hashRingEntry{Position: uint16(46982), Hostname: "10.0.0.1", DestinationIndex: 0},
+		hashRingEntry{Position: uint16(54295), Hostname: "127.0.0.1", Instance: "b", DestinationIndex: 2}}
+	assert.Equal(t, expectedHashRing, hasher.Ring)
+	hasher.AddDestination(&Destination{Addr: "127.0.0.1", Instance: "c"})
+	hasher.AddDestination(&Destination{Addr: "10.0.0.2"})
+	expectedHashRing = hashRing{
+		hashRingEntry{Position: uint16(6639), Hostname: "10.0.0.2", DestinationIndex: 4},
+		hashRingEntry{Position: uint16(7885), Hostname: "127.0.0.1", Instance: "a", DestinationIndex: 1},
+		hashRingEntry{Position: uint16(10461), Hostname: "127.0.0.1", Instance: "b", DestinationIndex: 2},
+		hashRingEntry{Position: uint16(24043), Hostname: "127.0.0.1", Instance: "a", DestinationIndex: 1},
+		hashRingEntry{Position: uint16(24467), Hostname: "127.0.0.1", Instance: "c", DestinationIndex: 3},
+		hashRingEntry{Position: uint16(35540), Hostname: "10.0.0.1", DestinationIndex: 0},
+		hashRingEntry{Position: uint16(46982), Hostname: "10.0.0.1", DestinationIndex: 0},
+		hashRingEntry{Position: uint16(52177), Hostname: "10.0.0.2", DestinationIndex: 4},
+		hashRingEntry{Position: uint16(53472), Hostname: "127.0.0.1", Instance: "c", DestinationIndex: 3},
+		hashRingEntry{Position: uint16(54295), Hostname: "127.0.0.1", Instance: "b", DestinationIndex: 2}}
+	assert.Equal(t, expectedHashRing, hasher.Ring)
+	assert.Equal(t, 4, hasher.GetDestinationIndex([]byte("a.b.c.d")))
+	assert.Equal(t, 1, hasher.GetDestinationIndex([]byte("a.b.c..d")))
+	assert.Equal(t, 3, hasher.GetDestinationIndex([]byte("collectd.bar.memory.free")))
+}

--- a/destination.go
+++ b/destination.go
@@ -15,12 +15,12 @@ func addrToPath(s string) string {
 
 func addrInstanceSplit(addr string) (string, string) {
 	var instance string
-	// The address may be specified as server:port or server:port:instance.
-	addrComponents := strings.Split(addr, ":")
-	if len(addrComponents) == 3 {
+	// The address may be specified as server, server:port or server:port:instance.
+	if strings.Count(addr, ":") == 3 {
+		addrComponents := strings.Split(addr, ":")
+		addr = strings.Join(addrComponents[0:2], ":")
 		instance = addrComponents[2]
 	}
-	addr = strings.Join(addrComponents[0:2], ":")
 	return addr, instance
 }
 

--- a/route.go
+++ b/route.go
@@ -6,9 +6,27 @@ import (
 	"sync/atomic"
 )
 
-type RouteConfig struct {
-	Matcher Matcher
-	Dests   []*Destination
+type RouteConfig interface {
+	Matcher() *Matcher
+	Dests() []*Destination
+}
+
+type baseRouteConfig struct {
+	matcher Matcher
+	dests   []*Destination
+}
+
+func (c baseRouteConfig) Matcher() *Matcher {
+	return &c.matcher
+}
+
+func (c baseRouteConfig) Dests() []*Destination {
+	return c.dests
+}
+
+type consistentHashingRouteConfig struct {
+	RouteConfig
+	Hasher ConsistentHasher
 }
 
 type Route interface {
@@ -45,6 +63,10 @@ type RouteSendFirstMatch struct {
 	baseRoute
 }
 
+type RouteConsistentHashing struct {
+	baseRoute
+}
+
 // NewRouteSendAllMatch creates a sendAllMatch route.
 // We will automatically run the route and the given destinations
 func NewRouteSendAllMatch(key, prefix, sub, regex string, destinations []*Destination) (Route, error) {
@@ -53,7 +75,7 @@ func NewRouteSendAllMatch(key, prefix, sub, regex string, destinations []*Destin
 		return nil, err
 	}
 	r := &RouteSendAllMatch{baseRoute{sync.Mutex{}, atomic.Value{}, key}}
-	r.config.Store(RouteConfig{*m, destinations})
+	r.config.Store(baseRouteConfig{*m, destinations})
 	r.run()
 	return r, nil
 }
@@ -66,14 +88,26 @@ func NewRouteSendFirstMatch(key, prefix, sub, regex string, destinations []*Dest
 		return nil, err
 	}
 	r := &RouteSendFirstMatch{baseRoute{sync.Mutex{}, atomic.Value{}, key}}
-	r.config.Store(RouteConfig{*m, destinations})
+	r.config.Store(baseRouteConfig{*m, destinations})
+	r.run()
+	return r, nil
+}
+
+func NewRouteConsistentHashing(key, prefix, sub, regex string, destinations []*Destination) (Route, error) {
+	m, err := NewMatcher(prefix, sub, regex)
+	if err != nil {
+		return nil, err
+	}
+	r := &RouteConsistentHashing{baseRoute{sync.Mutex{}, atomic.Value{}, key}}
+	r.config.Store(consistentHashingRouteConfig{baseRouteConfig{*m, destinations},
+		NewConsistentHasher(destinations)})
 	r.run()
 	return r, nil
 }
 
 func (route *baseRoute) run() {
 	conf := route.config.Load().(RouteConfig)
-	for _, dest := range conf.Dests {
+	for _, dest := range conf.Dests() {
 		dest.Run()
 	}
 }
@@ -81,7 +115,7 @@ func (route *baseRoute) run() {
 func (route *RouteSendAllMatch) Dispatch(buf []byte) {
 	conf := route.config.Load().(RouteConfig)
 
-	for _, dest := range conf.Dests {
+	for _, dest := range conf.Dests() {
 		if dest.Match(buf) {
 			// dest should handle this as quickly as it can
 			log.Info("route %s sending to dest %s: %s", route.key, dest.Addr, buf)
@@ -93,7 +127,7 @@ func (route *RouteSendAllMatch) Dispatch(buf []byte) {
 func (route *RouteSendFirstMatch) Dispatch(buf []byte) {
 	conf := route.config.Load().(RouteConfig)
 
-	for _, dest := range conf.Dests {
+	for _, dest := range conf.Dests() {
 		if dest.Match(buf) {
 			// dest should handle this as quickly as it can
 			log.Info("route %s sending to dest %s: %s", route.key, dest.Addr, buf)
@@ -103,19 +137,26 @@ func (route *RouteSendFirstMatch) Dispatch(buf []byte) {
 	}
 }
 
+func (route *RouteConsistentHashing) Dispatch(buf []byte) {
+	conf := route.config.Load().(consistentHashingRouteConfig)
+	dest := conf.Dests()[conf.Hasher.GetDestinationIndex(buf)]
+	log.Info("route %s sending to dest %s: %s", route.key, dest.Addr, buf)
+	dest.in <- buf
+}
+
 func (route *baseRoute) Key() string {
 	return route.key
 }
 
 func (route *baseRoute) Match(s []byte) bool {
 	conf := route.config.Load().(RouteConfig)
-	return conf.Matcher.Match(s)
+	return conf.Matcher().Match(s)
 }
 
 func (route *baseRoute) Flush() error {
 	conf := route.config.Load().(RouteConfig)
 
-	for _, d := range conf.Dests {
+	for _, d := range conf.Dests() {
 		err := d.Flush()
 		if err != nil {
 			return err
@@ -129,7 +170,7 @@ func (route *baseRoute) Shutdown() error {
 
 	destErrs := make([]error, 0)
 
-	for _, d := range conf.Dests {
+	for _, d := range conf.Dests() {
 		err := d.Shutdown()
 		if err != nil {
 			destErrs = append(destErrs, err)
@@ -147,53 +188,108 @@ func (route *baseRoute) Shutdown() error {
 }
 
 // to view the state of the table/route at any point in time
-func (route *RouteSendAllMatch) Snapshot() RouteSnapshot {
+func makeSnapshot(route *baseRoute, routeType string) RouteSnapshot {
 	conf := route.config.Load().(RouteConfig)
-	dests := make([]*Destination, len(conf.Dests))
-	for i, d := range conf.Dests {
+	dests := make([]*Destination, len(conf.Dests()))
+	for i, d := range conf.Dests() {
 		dests[i] = d.Snapshot()
 	}
-	return RouteSnapshot{conf.Matcher, dests, "sendAllMatch", route.key}
+	return RouteSnapshot{*conf.Matcher(), dests, routeType, route.key}
+
+}
+
+func (route *RouteSendAllMatch) Snapshot() RouteSnapshot {
+	return makeSnapshot(&route.baseRoute, "sendAllMatch")
 }
 
 func (route *RouteSendFirstMatch) Snapshot() RouteSnapshot {
-	conf := route.config.Load().(RouteConfig)
-	dests := make([]*Destination, len(conf.Dests))
-	for i, d := range conf.Dests {
-		dests[i] = d.Snapshot()
-	}
-	return RouteSnapshot{conf.Matcher, dests, "sendFirstMatch", route.key}
+	return makeSnapshot(&route.baseRoute, "sendFirstMatch")
+}
+
+func (route *RouteConsistentHashing) Snapshot() RouteSnapshot {
+	return makeSnapshot(&route.baseRoute, "consistentHashing")
+}
+
+// baseConfigExtender is a function that takes a baseRouteConfig and returns
+// a configuration object that implements RouteConfig. This function may be
+// the identity function, i.e., it may simply return its argument.
+// This mechanism supports maintaining different configuration objects for
+// different route types and creating a route-appropriate configuration object
+// on a configuration change.
+// The baseRoute object implements private methods (addDestination,
+// delDestination, etc.) that create a new baseRouteConfig object that reflects
+// the configuration change. This baseRouteConfig object is applicable to all
+// route types. However, some route types, like ConsistentHashingRoute, have
+// additional configuration and therefore have a distinct configuration object
+// that embeds baseRouteConfig (in the case of ConsistentHashingRoute, the object
+// is consistentHashingRouteConfig). This route-type-specific configuration also
+// needs to be updated on a base configuration change (e.g., on a change
+// affecting destinations). Accordingly, the public entry points that effect the
+// configuration change (Add, DelDestination, etc.) are implemented for baseRoute
+// and also for any route type, like ConsistentHashingRoute, that creates a
+// configuration object. These public entry points call the private method,
+// passing in a callback function of type baseConfigExtender, which takes a
+// baseRouteConfig and either returns it unchanged or creates an outer
+// configuration object with the baseRouteConfig embedded in it.
+// The private method then stores the RouteConfig object returned by the callback.
+type baseConfigExtender func(baseRouteConfig) RouteConfig
+
+func baseRouteConfigExtender(baseConfig baseRouteConfig) RouteConfig {
+	return baseConfig
+}
+
+func consistentHashingRouteConfigExtender(baseConfig baseRouteConfig) RouteConfig {
+	return consistentHashingRouteConfig{baseConfig,
+		NewConsistentHasher(baseConfig.Dests())}
 }
 
 // Add adds a new Destination to the Route and automatically runs it for you.
 // The destination must not be running already!
-func (route *baseRoute) Add(dest *Destination) {
+func (route *baseRoute) addDestination(dest *Destination, extendConfig baseConfigExtender) {
 	route.Lock()
 	defer route.Unlock()
 	conf := route.config.Load().(RouteConfig)
 	dest.Run()
-	conf.Dests = append(conf.Dests, dest)
-	route.config.Store(conf)
+	newDests := append(conf.Dests(), dest)
+	newConf := extendConfig(baseRouteConfig{*conf.Matcher(), newDests})
+	route.config.Store(newConf)
 }
 
-func (route *baseRoute) DelDestination(index int) error {
+func (route *baseRoute) Add(dest *Destination) {
+	route.addDestination(dest, baseRouteConfigExtender)
+}
+
+func (route *RouteConsistentHashing) Add(dest *Destination) {
+	route.addDestination(dest, consistentHashingRouteConfigExtender)
+}
+
+func (route *baseRoute) delDestination(index int, extendConfig baseConfigExtender) error {
 	route.Lock()
 	defer route.Unlock()
 	conf := route.config.Load().(RouteConfig)
-	if index >= len(conf.Dests) {
+	if index >= len(conf.Dests()) {
 		return fmt.Errorf("Invalid index %d", index)
 	}
-	conf.Dests[index].Shutdown()
-	conf.Dests = append(conf.Dests[:index], conf.Dests[index+1:]...)
-	route.config.Store(conf)
+	conf.Dests()[index].Shutdown()
+	newDests := append(conf.Dests()[:index], conf.Dests()[index+1:]...)
+	newConf := extendConfig(baseRouteConfig{*conf.Matcher(), newDests})
+	route.config.Store(newConf)
 	return nil
 }
 
-func (route *baseRoute) Update(opts map[string]string) error {
+func (route *baseRoute) DelDestination(index int) error {
+	return route.delDestination(index, baseRouteConfigExtender)
+}
+
+func (route *RouteConsistentHashing) DelDestination(index int) error {
+	return route.delDestination(index, consistentHashingRouteConfigExtender)
+}
+
+func (route *baseRoute) update(opts map[string]string, extendConfig baseConfigExtender) error {
 	route.Lock()
 	defer route.Unlock()
 	conf := route.config.Load().(RouteConfig)
-	matcher := conf.Matcher
+	matcher := conf.Matcher()
 	prefix := matcher.Prefix
 	sub := matcher.Sub
 	regex := matcher.Regex
@@ -219,23 +315,56 @@ func (route *baseRoute) Update(opts map[string]string) error {
 		if err != nil {
 			return err
 		}
-		conf.Matcher = *matcher
+		conf = extendConfig(baseRouteConfig{*matcher, conf.Dests()})
 	}
 	route.config.Store(conf)
 	return nil
 }
-func (route *baseRoute) UpdateDestination(index int, opts map[string]string) error {
-	conf := route.config.Load().(RouteConfig)
-	if index >= len(conf.Dests) {
-		return fmt.Errorf("Invalid index %d", index)
-	}
-	return conf.Dests[index].Update(opts)
+
+func (route *baseRoute) Update(opts map[string]string) error {
+	return route.update(opts, baseRouteConfigExtender)
 }
 
-func (route *baseRoute) UpdateMatcher(matcher Matcher) {
+func (route *RouteConsistentHashing) Update(opts map[string]string) error {
+	return route.update(opts, consistentHashingRouteConfigExtender)
+}
+
+func (route *baseRoute) updateDestination(index int, opts map[string]string, extendConfig baseConfigExtender) error {
 	route.Lock()
 	defer route.Unlock()
 	conf := route.config.Load().(RouteConfig)
-	conf.Matcher = matcher
+	if index >= len(conf.Dests()) {
+		return fmt.Errorf("Invalid index %d", index)
+	}
+	err := conf.Dests()[index].Update(opts)
+	if err != nil {
+		return err
+	}
+	conf = extendConfig(baseRouteConfig{*conf.Matcher(), conf.Dests()})
 	route.config.Store(conf)
+	return nil
+}
+
+func (route *baseRoute) UpdateDestination(index int, opts map[string]string) error {
+	return route.updateDestination(index, opts, baseRouteConfigExtender)
+}
+
+func (route *RouteConsistentHashing) UpdateDestination(index int, opts map[string]string) error {
+	return route.updateDestination(index, opts, consistentHashingRouteConfigExtender)
+}
+
+func (route *baseRoute) updateMatcher(matcher Matcher, extendConfig baseConfigExtender) {
+	route.Lock()
+	defer route.Unlock()
+	conf := route.config.Load().(RouteConfig)
+	conf = extendConfig(baseRouteConfig{matcher, conf.Dests()})
+	route.config.Store(conf)
+}
+
+func (route *baseRoute) UpdateMatcher(matcher Matcher) {
+	route.updateMatcher(matcher, baseRouteConfigExtender)
+}
+
+func (route *RouteConsistentHashing) UpdateMatcher(matcher Matcher) {
+	route.updateMatcher(matcher, consistentHashingRouteConfigExtender)
 }


### PR DESCRIPTION
Consistent hashing algorithm is same as in carbon.

Configuration syntax is
```
addRoute consistentHashing <route_name>  <server1>:<port1>:<instance1> <options...>  <server1>:<port1>:<instance1> <options...>  ...  <servern>:<portn>:<instancen> <options...>
```

Example:

addRoute consistentHashing cache  127.0.0.1:2013:a pickle=false  127.0.0.1:2023:b pickle=true