### PR TITLE
Add prepend and append options for destinations

### DIFF
--- a/admin_http.go
+++ b/admin_http.go
@@ -3,13 +3,14 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	assetfs "github.com/elazarl/go-bindata-assetfs"
-	"github.com/gorilla/mux"
-	"github.com/graphite-ng/carbon-relay-ng/aggregator"
 	"net/http"
 	"os"
 	"strconv"
 	"time"
+
+	assetfs "github.com/elazarl/go-bindata-assetfs"
+	"github.com/gorilla/mux"
+	"github.com/graphite-ng/carbon-relay-ng/aggregator"
 )
 
 // error response contains everything we need to use http.Error
@@ -132,6 +133,8 @@ func parseRouteRequest(r *http.Request) (Route, *handlerError) {
 		Substring string
 		Prefix    string
 		Regex     string
+		Prepend   string
+		Append    string
 	}
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, &handlerError{err, "Couldn't parse json", http.StatusBadRequest}
@@ -140,7 +143,7 @@ func parseRouteRequest(r *http.Request) (Route, *handlerError) {
 	// readDestinations
 	periodFlush := time.Duration(1000) * time.Millisecond
 	periodReconn := time.Duration(10000) * time.Millisecond
-	dest, err := NewDestination("", "", "", request.Address, table.spoolDir, request.Spool, request.Pickle, periodFlush, periodReconn)
+	dest, err := NewDestination("", "", "", request.Address, table.spoolDir, request.Prepend, request.Append, request.Spool, request.Pickle, periodFlush, periodReconn)
 	if err != nil {
 		return nil, &handlerError{err, "unable to create destination", http.StatusBadRequest}
 	}

--- a/carbon-relay-ng.ini
+++ b/carbon-relay-ng.ini
@@ -24,12 +24,13 @@ legacy_metric_validation = "strict"
 # here's some examples:
 init = [
      'addBlack prefix collectd.localhost',  # ignore hosts that don't set their hostname properly (implicit substring matrch).
-     'addBlack regex ^foo\..*\.cpu+', # ignore foo.<anything>.cpu.... (regex pattern match)
-     'addAgg sum ^stats\.timers\.(app|proxy|static)[0-9]+\.requests\.(.*) stats.timers._sum_$1.requests.$2 10 20',
-     'addAgg avg ^stats\.timers\.(app|proxy|static)[0-9]+\.requests\.(.*) stats.timers._avg_$1.requests.$2 5 10',
-     'addRoute sendAllMatch carbon-default  127.0.0.1:2005 spool=true pickle=false',
-     'addRoute sendAllMatch carbon-tagger sub==  127.0.0.1:2006',  # all metrics with '=' in them are metrics2.0 format for tagger
-     'addRoute sendFirstMatch analytics regex=(Err/s|wait_time|logger)  graphite.prod:2003 prefix=prod. spool=true pickle=true  graphite.staging:2003 prefix=staging. spool=true pickle=true'
+#     'addBlack regex ^foo\..*\.cpu+', # ignore foo.<anything>.cpu.... (regex pattern match)
+#     'addAgg sum ^stats\.timers\.(app|proxy|static)[0-9]+\.requests\.(.*) stats.timers._sum_$1.requests.$2 10 20',
+#     'addAgg avg ^stats\.timers\.(app|proxy|static)[0-9]+\.requests\.(.*) stats.timers._avg_$1.requests.$2 5 10',
+#     'addRoute sendAllMatch carbon-default  127.0.0.1:2005 spool=true pickle=false',
+     'addRoute sendAllMatch carbon-default  127.0.0.1:2005 prepend=hello. append=.world spool=true pickle=false',
+#     'addRoute sendAllMatch carbon-tagger sub==  127.0.0.1:2006',  # all metrics with '=' in them are metrics2.0 format for tagger
+#     'addRoute sendFirstMatch analytics regex=(Err/s|wait_time|logger)  graphite.prod:2003 prefix=prod. spool=true pickle=true  graphite.staging:2003 prefix=staging. spool=true pickle=true'
 ]
 
 [instrumentation]


### PR DESCRIPTION
This is an preliminary attempt to add support for prepending, and
appending, some arbitrary strings to the metrics name of before
relaying onward.

  I'm raising this to see if you are at all interested in this, or
if you think this should part of the relay at all. There will be
a minor performance impact when the settings are not used.

  Prepending should be reasonably efficient.

  Appending will create a fair bit of garbage in the current
implementation.

  I've not benchmarked either option yet, but can do if you are
interested in integrating something like this.

  I've also not added the web interface support yet.
