### PR TITLE
use exec form for ENTRYPOINT and CMD in Dockerfile

### DIFF
--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -4,6 +4,6 @@ ADD carbon-relay-ng /bin/
 
 VOLUME /conf
 
-ENTRYPOINT /bin/carbon-relay-ng
+ENTRYPOINT ["/bin/carbon-relay-ng"]
 
-CMD /conf/carbon-relay-ng.ini
+CMD ["/conf/carbon-relay-ng.ini"]


### PR DESCRIPTION
This is a simple change to use exec form instead the shell form for ENTRYPOINT and CMD in Dockerfile. exec form ENTRYPOINT is recommended by docker, also it allows additional parameters from the command line. Be aware that any command line parameters would override the elements listed in CMD. 