### PR TITLE
Some debian packaging updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'fpm'

--- a/Makefile
+++ b/Makefile
@@ -7,21 +7,30 @@ build:
 
 all:
 
-deb: build
+deb: deb-systemd
+
+deb-systemd: build deb-common
 	mkdir -p build/deb-systemd
-	install -d debian/usr/bin debian/usr/share/man/man1 debian/etc/carbon-relay-ng debian/lib/systemd/system debian/var/run/carbon-relay-ng
-	install carbon-relay-ng debian/usr/bin
-	install examples/carbon-relay-ng.ini debian/etc/carbon-relay-ng/carbon-relay-ng.conf
+	install -d debian/lib/systemd/system
 	install examples/carbon-relay-ng.service debian/lib/systemd/system
-	install man/man1/carbon-relay-ng.1 debian/usr/share/man/man1
-	gzip debian/usr/share/man/man1/carbon-relay-ng.1
-	fpm \
+	DEBDIR=build/deb-systemd $(MAKE) deb-fpm
+
+deb-upstart: build deb-common
+	mkdir -p build/deb-upstart
+	DEBDIR=build/deb-upstart FPMARGS="--deb-upstart examples/carbon-relay-ng.upstart" $(MAKE) deb-fpm
+
+deb-nostart: build deb-common
+	mkdir -p build/deb-nostart
+	DEBDIR=build/deb-nostart $(MAKE) deb-fpm
+
+deb-fpm:
+	fpm $(FPMARGS) \
 		-s dir \
 		-t deb \
 		-n carbon-relay-ng \
 		-v $(VERSION)-1 \
 		-a native \
-		-p build/deb-systemd/carbon-relay-ng-VERSION_ARCH.deb \
+		-p $(DEBDIR)/carbon-relay-ng-VERSION_ARCH.deb \
 		-m "Dieter Plaetinck <dieter@raintank.io>" \
 		--description "Fast carbon relay+aggregator with admin interfaces for making changes online" \
 		--license BSD \
@@ -29,27 +38,18 @@ deb: build
 		-C debian .
 	rm -rf debian
 
-deb-upstart: build
-	mkdir build/deb-upstart
-	install -d debian/usr/bin debian/usr/share/man/man1 debian/etc/carbon-relay-ng
-	install carbon-relay-ng debian/usr/bin
+
+deb-common:
+	install -d debian/etc/carbon-relay-ng
 	install examples/carbon-relay-ng.ini debian/etc/carbon-relay-ng/carbon-relay-ng.conf
+	install -d debian/var/run/carbon-relay-ng
+	install -d debian/usr/bin
+	install carbon-relay-ng debian/usr/bin
+	install -d debian/usr/share/man/man1
 	install man/man1/carbon-relay-ng.1 debian/usr/share/man/man1
 	gzip debian/usr/share/man/man1/carbon-relay-ng.1
-	fpm \
-		-s dir \
-		-t deb \
-		-n carbon-relay-ng \
-		-v $(VERSION)-1 \
-		-a native \
-		-p build/deb-upstart/carbon-relay-ng-VERSION_ARCH.deb \
-		--deb-upstart examples/carbon-relay-ng.upstart \
-		-m "Dieter Plaetinck <dieter@raintank.io>" \
-		--description "Fast carbon relay+aggregator with admin interfaces for making changes online" \
-		--license BSD \
-		--url https://github.com/graphite-ng/carbon-relay-ng \
-		-C debian .
-	rm -rf debian
+	install -d debian/usr/share/doc/carbon-relay-ng/examples
+	install examples/* debian/usr/share/doc/carbon-relay-ng/examples
 
 rpm: build
 	mkdir -p build/centos-7


### PR DESCRIPTION
Hi! This is a speculative PR. As I'm seeing issues with the circleci builds (https://github.com/graphite-ng/carbon-relay-ng/issues/142) , I thought I'd pull the builds into my own CI system. In doing so, I found I wanted a couple of changes.

I wanted to build a debian package without start scripts. So I added a target, and refactored out the common parts of all the debian variants. 

I also added a Gemfile for the `fpm` gem, which packing needs.

What do you think?