### PR TITLE
Add support to big.int timestamp

### DIFF
--- a/input/pickle.go
+++ b/input/pickle.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 
 	"github.com/graphite-ng/carbon-relay-ng/badmetrics"
@@ -139,7 +140,7 @@ ReadLoop:
 			switch data[0].(type) {
 			case string:
 				timestamp = data[0].(string)
-			case uint8, uint16, uint32, uint64, int8, int16, int32, int64:
+			case uint8, uint16, uint32, uint64, int8, int16, int32, int64, (*big.Int):
 				timestamp = fmt.Sprintf("%d", data[0])
 			case float32, float64:
 				timestamp = fmt.Sprintf("%.0f", data[0])


### PR DESCRIPTION
On my installation it's generate a ton of logs like
```
13:11:53.953998 ▶ ERRO  Unrecognized type *big.Int for timestamp
13:11:53.954006 ▶ ERRO  Unrecognized type *big.Int for timestamp
13:11:53.954014 ▶ ERRO  Unrecognized type *big.Int for timestamp
13:11:53.954027 ▶ ERRO  Unrecognized type *big.Int for timestamp
13:11:53.954036 ▶ ERRO  Unrecognized type *big.Int for timestamp
13:11:53.954044 ▶ ERRO  Unrecognized type *big.Int for timestamp
```
as proxy between pickle protocol and influxdb.

Just fixed it.