### PR TITLE
fix metrics initialisation

### DIFF
--- a/cmd/carbon-relay-ng/carbon-relay-ng.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng.go
@@ -138,6 +138,8 @@ func main() {
 		f.Close()
 	}
 
+	input.InitMetrics()
+
 	if config.Instrumentation.Graphite_addr != "" {
 		addr, err := net.ResolveTCPAddr("tcp", config.Instrumentation.Graphite_addr)
 		if err != nil {

--- a/input/init.go
+++ b/input/init.go
@@ -15,7 +15,7 @@ var (
 	numOutOfOrder metrics.Counter
 )
 
-func init() {
+func InitMetrics() {
 	numIn = stats.Counter("unit=Metric.direction=in")
 	numInvalid = stats.Counter("unit=Err.type=invalid")
 	numOutOfOrder = stats.Counter("unit=Err.type=out_of_order")


### PR DESCRIPTION
in f6a154e703c8a0017837623b2a2f728772ba4f6d we changed metrics to create
them via init(), but then the instance was not properly set yet, so we
have to wait to a more appropriate time.

fix #149