### PR TITLE
Amqp features

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -35,7 +35,6 @@ type Amqp struct {
 	Amqp_password  string
 	Amqp_exchange  string
 	Amqp_queue     string
-	Amqp_ack       bool
 	Amqp_durable   bool
 	Amqp_exclusive bool
 }

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -35,6 +35,7 @@ type Amqp struct {
 	Amqp_password  string
 	Amqp_exchange  string
 	Amqp_queue     string
+	Amqp_key       string
 	Amqp_durable   bool
 	Amqp_exclusive bool
 }

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -27,17 +27,17 @@ type Config struct {
 }
 
 type Amqp struct {
-	Amqp_enabled  	bool
-	Amqp_host     	string
-	Amqp_port     	int
-	Amqp_vhost    	string
-	Amqp_user     	string
-	Amqp_password 	string
-	Amqp_exchange 	string
-	Amqp_queue			string
-	Amqp_ack				bool
-	Amqp_durable		bool
-	Amqp_exclusive	bool
+	Amqp_enabled   bool
+	Amqp_host      string
+	Amqp_port      int
+	Amqp_vhost     string
+	Amqp_user      string
+	Amqp_password  string
+	Amqp_exchange  string
+	Amqp_queue     string
+	Amqp_ack       bool
+	Amqp_durable   bool
+	Amqp_exclusive bool
 }
 
 type instrumentation struct {

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -27,13 +27,17 @@ type Config struct {
 }
 
 type Amqp struct {
-	Amqp_enabled  bool
-	Amqp_host     string
-	Amqp_port     int
-	Amqp_vhost    string
-	Amqp_user     string
-	Amqp_password string
-	Amqp_exchange string
+	Amqp_enabled  	bool
+	Amqp_host     	string
+	Amqp_port     	int
+	Amqp_vhost    	string
+	Amqp_user     	string
+	Amqp_password 	string
+	Amqp_exchange 	string
+	Amqp_queue			string
+	Amqp_ack				bool
+	Amqp_durable		bool
+	Amqp_exclusive	bool
 }
 
 type instrumentation struct {

--- a/examples/carbon-relay-ng.ini
+++ b/examples/carbon-relay-ng.ini
@@ -51,6 +51,9 @@ amqp_user = "guest"
 amqp_password = "guest"
 amqp_vhost = "/graphite"
 amqp_exchange = "metrics"
+Amqp_ack = false
+Amqp_durable = false
+Amqp_exclusive = true
 
 [instrumentation]
 # in addition to serving internal metrics via expvar, you can optionally send em to graphite

--- a/examples/carbon-relay-ng.ini
+++ b/examples/carbon-relay-ng.ini
@@ -52,7 +52,6 @@ amqp_password = "guest"
 amqp_vhost = "/graphite"
 amqp_exchange = "metrics"
 amqp_queue = ""
-amqp_ack = false
 amqp_durable = false
 amqp_exclusive = true
 

--- a/examples/carbon-relay-ng.ini
+++ b/examples/carbon-relay-ng.ini
@@ -51,6 +51,7 @@ amqp_user = "guest"
 amqp_password = "guest"
 amqp_vhost = "/graphite"
 amqp_exchange = "metrics"
+Amqp_queue = ""
 Amqp_ack = false
 Amqp_durable = false
 Amqp_exclusive = true

--- a/examples/carbon-relay-ng.ini
+++ b/examples/carbon-relay-ng.ini
@@ -51,10 +51,10 @@ amqp_user = "guest"
 amqp_password = "guest"
 amqp_vhost = "/graphite"
 amqp_exchange = "metrics"
-Amqp_queue = ""
-Amqp_ack = false
-Amqp_durable = false
-Amqp_exclusive = true
+amqp_queue = ""
+amqp_ack = false
+amqp_durable = false
+amqp_exclusive = true
 
 [instrumentation]
 # in addition to serving internal metrics via expvar, you can optionally send em to graphite

--- a/examples/carbon-relay-ng.ini
+++ b/examples/carbon-relay-ng.ini
@@ -52,6 +52,7 @@ amqp_password = "guest"
 amqp_vhost = "/graphite"
 amqp_exchange = "metrics"
 amqp_queue = ""
+amqp_key = "#"
 amqp_durable = false
 amqp_exclusive = true
 

--- a/input/amqp.go
+++ b/input/amqp.go
@@ -89,7 +89,7 @@ func connectAMQP(a *Amqp) (<-chan amqp.Delivery, error) {
 	a.channel = amqpChan
 
 	// queue name will be random, as in the python implementation
-	q, err := amqpChan.QueueDeclare("", false, false, true, false, nil)
+	q, err := amqpChan.QueueDeclare(a.config.Amqp.Amqp_queue, a.config.Amqp.Amqp_durable, false, a.config.Amqp.Amqp_exclusive, false, nil)
 	if err != nil {
 		a.close()
 		return nil, err

--- a/input/amqp.go
+++ b/input/amqp.go
@@ -95,7 +95,7 @@ func connectAMQP(a *Amqp) (<-chan amqp.Delivery, error) {
 		return nil, err
 	}
 
-	err = amqpChan.QueueBind(q.Name, "#", a.config.Amqp.Amqp_exchange, false, nil)
+	err = amqpChan.QueueBind(q.Name, a.config.Amqp.Amqp_key, a.config.Amqp.Amqp_exchange, false, nil)
 	if err != nil {
 		a.close()
 		return nil, err

--- a/input/amqp.go
+++ b/input/amqp.go
@@ -101,7 +101,7 @@ func connectAMQP(a *Amqp) (<-chan amqp.Delivery, error) {
 		return nil, err
 	}
 
-	c, err := amqpChan.Consume(q.Name, "carbon-relay-ng", !a.config.Amqp.Amqp_ack, a.config.Amqp.Amqp_exclusive, true, false, nil)
+	c, err := amqpChan.Consume(q.Name, "carbon-relay-ng", true, a.config.Amqp.Amqp_exclusive, true, false, nil)
 	if err != nil {
 		a.close()
 		return nil, err

--- a/input/amqp.go
+++ b/input/amqp.go
@@ -101,7 +101,7 @@ func connectAMQP(a *Amqp) (<-chan amqp.Delivery, error) {
 		return nil, err
 	}
 
-	c, err := amqpChan.Consume(q.Name, "carbon-relay-ng", !a.config.Amqp.Amqp_durable, true, true, false, nil)
+	c, err := amqpChan.Consume(q.Name, "carbon-relay-ng", !a.config.Amqp.Amqp_ack, true, true, false, nil)
 	if err != nil {
 		a.close()
 		return nil, err

--- a/input/amqp.go
+++ b/input/amqp.go
@@ -101,7 +101,7 @@ func connectAMQP(a *Amqp) (<-chan amqp.Delivery, error) {
 		return nil, err
 	}
 
-	c, err := amqpChan.Consume(q.Name, "carbon-relay-ng", true, true, true, false, nil)
+	c, err := amqpChan.Consume(q.Name, "carbon-relay-ng", !a.config.Amqp.Amqp_durable, true, true, false, nil)
 	if err != nil {
 		a.close()
 		return nil, err

--- a/input/amqp.go
+++ b/input/amqp.go
@@ -101,7 +101,7 @@ func connectAMQP(a *Amqp) (<-chan amqp.Delivery, error) {
 		return nil, err
 	}
 
-	c, err := amqpChan.Consume(q.Name, "carbon-relay-ng", !a.config.Amqp.Amqp_ack, true, true, false, nil)
+	c, err := amqpChan.Consume(q.Name, "carbon-relay-ng", !a.config.Amqp.Amqp_ack, a.config.Amqp.Amqp_exclusive, true, false, nil)
 	if err != nil {
 		a.close()
 		return nil, err


### PR DESCRIPTION
According to #163
Four parameters are added to the configuration file:
- amqp_queue: if the parameter is not an empty string, the queue name won't be randomized
- amqp_ack: message acknowledgment (default is false)
- amqp_durable: is the queue durable? (default is false)
- amqp_exclusive: is the queue exclusive? (default is false)
