### PR TITLE
govendor update github.com/kisielk/og-rek to revision 661228609bd14f4656ba43558b2b0dd99b03296f

### DIFF
--- a/vendor/github.com/kisielk/og-rek/README.md
+++ b/vendor/github.com/kisielk/og-rek/README.md
@@ -1,4 +1,17 @@
-og-rek
+ogórek
 ======
+[![GoDoc](https://godoc.org/github.com/kisielk/og-rek?status.svg)](https://godoc.org/github.com/kisielk/og-rek)
+[![Build Status](https://travis-ci.org/kisielk/og-rek.svg?branch=master)](https://travis-ci.org/kisielk/og-rek)
 
 ogórek is a Go library for encoding and decoding pickles.
+
+Fuzz Testing
+------------
+Fuzz testing has been implemented for the decoder. To run fuzz tests do the following:
+
+```
+go get github.com/dvyukov/go-fuzz/go-fuzz
+go get github.com/dvyukov/go-fuzz/go-fuzz-build
+go-fuzz-build github.com/kisielk/og-rek
+go-fuzz -bin=./ogórek-fuzz.zip -workdir=./fuzz
+```

--- a/vendor/github.com/kisielk/og-rek/fuzz.go
+++ b/vendor/github.com/kisielk/og-rek/fuzz.go
@@ -1,0 +1,17 @@
+// +build gofuzz
+
+package ogórek
+
+import (
+	"bytes"
+)
+
+func Fuzz(data []byte) int {
+	buf := bytes.NewBuffer(data)
+	dec := NewDecoder(buf)
+	_, err := dec.Decode()
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -117,10 +117,10 @@
 			"revisionTime": "2016-04-14T05:52:04Z"
 		},
 		{
-			"checksumSHA1": "st+4hfayyAIfSPbW5rhKspzKKEc=",
+			"checksumSHA1": "ornGgbnVpwBoID7VKjFLTgkntA0=",
 			"path": "github.com/kisielk/og-rek",
-			"revision": "28bae785206e71d70d9c770903d06abb87547734",
-			"revisionTime": "2016-01-04T20:53:23Z"
+			"revision": "661228609bd14f4656ba43558b2b0dd99b03296f",
+			"revisionTime": "2017-03-09T19:35:12Z"
 		},
 		{
 			"checksumSHA1": "7ttJJBMDGKL63tX23fNmW7r7NvQ=",


### PR DESCRIPTION
Updated kisielk/ogórek to address #171. No longer observing crashes, there's no drop in metrics compared to combined carbon-relay-ng for line and Python carbon-relay for pickled metrics (FYI we're receiving around 900k metrics per minute). Instead of crashing, we can now see the following error in logs:
```
13:30:09.836044 ▶ ERRO  Unrecognized type ogórek.Tuple for item
```