### PR TITLE
updated pickle.go to use ogorek.Tuple instead []interface{} type for item and data

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -117,10 +117,10 @@
 			"revisionTime": "2016-04-14T05:52:04Z"
 		},
 		{
-			"checksumSHA1": "ornGgbnVpwBoID7VKjFLTgkntA0=",
+			"checksumSHA1": "6s2IAJ1smhtl7YePdwZZ1J2zqeA=",
 			"path": "github.com/kisielk/og-rek",
-			"revision": "661228609bd14f4656ba43558b2b0dd99b03296f",
-			"revisionTime": "2017-03-09T19:35:12Z"
+			"revision": "ec792bc6e6aa06a6c490e8d292e15cca173c8bd3",
+			"revisionTime": "2017-04-05T22:37:46Z"
 		},
 		{
 			"checksumSHA1": "7ttJJBMDGKL63tX23fNmW7r7NvQ=",


### PR DESCRIPTION
It seems that upstream module, kisielk/ogorek, created a custom type `Tuple` to reflect Python's tuple. In order for carbon-relay-ng to use the new ogorek version, I had to switch from `[]interface{}` to `ogorek.Tuple` for `item` and `data`. My apologies for I didn't see this all the way through when I PR'd the new ogorek version.