### PR TITLE
Updated kisielk/og-rek, data type changes due to this update and pickle.go debug info

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -117,10 +117,10 @@
 			"revisionTime": "2016-04-14T05:52:04Z"
 		},
 		{
-			"checksumSHA1": "ornGgbnVpwBoID7VKjFLTgkntA0=",
+			"checksumSHA1": "6s2IAJ1smhtl7YePdwZZ1J2zqeA=",
 			"path": "github.com/kisielk/og-rek",
-			"revision": "661228609bd14f4656ba43558b2b0dd99b03296f",
-			"revisionTime": "2017-03-09T19:35:12Z"
+			"revision": "ec792bc6e6aa06a6c490e8d292e15cca173c8bd3",
+			"revisionTime": "2017-04-05T22:37:46Z"
 		},
 		{
 			"checksumSHA1": "7ttJJBMDGKL63tX23fNmW7r7NvQ=",


### PR DESCRIPTION
1. updated kisielk/og-rek to revision ec792bc
2. changed []interface{} to ogorek.Tuple to reflect the changes to ogorek
3. decorated pickle.go with debugging information

Tested with some pickled data, works as intended

PS: I had an issue with some production pickled data from an outdated Java client, but upon closer inspection of the tcpdump it turned out its header is erroneously 8 bytes long (ie. it's not 4 bytes as the spec dictates), so carbon-relay-ng "correctly" detects payload size of zero upon reading the first 4 bytes and exits with EOF error.

More tests and comments welcome, of course.