### PR TITLE
Add tmpfiles.d config for deb package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,10 @@ all:
 
 deb: build
 	mkdir -p build/deb-systemd
-	install -d debian/usr/bin debian/usr/share/man/man1 debian/etc/carbon-relay-ng debian/lib/systemd/system debian/var/run/carbon-relay-ng
+	install -d debian/usr/bin debian/usr/share/man/man1 debian/etc/carbon-relay-ng debian/lib/systemd/system debian/var/run/carbon-relay-ng debian/usr/lib/tmpfiles.d
 	install carbon-relay-ng debian/usr/bin
 	install examples/carbon-relay-ng.ini debian/etc/carbon-relay-ng/carbon-relay-ng.conf
+	install examples/carbon-relay-ng-tmpfiles.conf debian/usr/lib/tmpfiles.d/carbon-relay-ng.conf
 	install examples/carbon-relay-ng.service debian/lib/systemd/system
 	install man/man1/carbon-relay-ng.1 debian/usr/share/man/man1
 	gzip debian/usr/share/man/man1/carbon-relay-ng.1

--- a/examples/carbon-relay-ng-tmpfiles.conf
+++ b/examples/carbon-relay-ng-tmpfiles.conf
@@ -1,0 +1,2 @@
+# Create tmp dir in /run, install into /usr/lib/tempfiles.d/
+d /run/carbon-relay-ng 0700 carbon-relay-ng carbon-relay-ng -


### PR DESCRIPTION
   As in #177 the package requires /var/run/carbon-relay-ng by default.
   Add an example tmpfiles.d config to the source
   Add this file to the deb in makefile.