### PR TITLE
prevent erasing of configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ deb: build
 		-n carbon-relay-ng \
 		-v $(VERSION)-1 \
 		-a native \
+		--config-files etc/carbon-relay-ng/carbon-relay-ng.conf \
 		-p build/deb-systemd/carbon-relay-ng-VERSION_ARCH.deb \
 		-m "Dieter Plaetinck <dieter@raintank.io>" \
 		--description "Fast carbon relay+aggregator with admin interfaces for making changes online" \
@@ -47,6 +48,7 @@ deb-upstart: build
 		-n carbon-relay-ng \
 		-v $(VERSION)-1 \
 		-a native \
+		--config-files etc/carbon-relay-ng/carbon-relay-ng.conf \
 		-p build/deb-upstart/carbon-relay-ng-VERSION_ARCH.deb \
 		--deb-upstart examples/carbon-relay-ng.upstart \
 		-m "Dieter Plaetinck <dieter@raintank.io>" \
@@ -71,6 +73,7 @@ rpm: build
 		-v $(VERSION) \
 		--epoch 1 \
 		-a native \
+		--config-files etc/carbon-relay-ng/carbon-relay-ng.conf \
 		-p build/centos-7/carbon-relay-ng-VERSION.el7.ARCH.rpm \
 		-m "Dieter Plaetinck <dieter@raintank.io>" \
 		--description "Fast carbon relay+aggregator with admin interfaces for making changes online" \
@@ -94,6 +97,7 @@ rpm-centos6: build
 		-v $(VERSION) \
 		--epoch 1 \
 		-a native \
+		--config-files etc/carbon-relay-ng/carbon-relay-ng.conf \
 		-p build/centos-6/carbon-relay-ng-VERSION.el6.ARCH.rpm \
 		-m "Dieter Plaetinck <dieter@raintank.io>" \
 		--description "Fast carbon relay+aggregator with admin interfaces for making changes online" \


### PR DESCRIPTION
Config files are overwritten with this current setup. 

This will build the rpm to install the config to /etc/carbon-relay-ng/carbon-relay-ng.conf.rpm if the file already exists. 

I do not know if this flag works for debian and i do not have a build environment setup for carbon-relay-ng at this time so this PR is untested. I have used the config flag on fpm though many times.