### PR TITLE
added more logging for failed producers

### DIFF
--- a/route/kafkamdm.go
+++ b/route/kafkamdm.go
@@ -152,6 +152,12 @@ func (r *KafkaMdm) run() {
 			}
 			err = r.producer.SendMessages(payload)
 
+			if err != nil {
+				for _, error := range err.(sarama.ProducerErrors) {
+					log.Error("Write to kafka failed: ", error)
+				}
+			}
+
 			diff := time.Since(pre)
 			if err == nil {
 				log.Info("KafkaMdm %q: sent %d metrics in %s - msg size %d", r.key, len(metrics), diff, size)


### PR DESCRIPTION
#186 

Its extremely verbose... however it is a critical problem that the user should know about and fix. 

To test:
1. Startup kafka in docker
2. set your config to point to localhost:9092

The relay will need to dial back to the docker host name which it cannot resolve when setup this way.

```
11:37:05.483597 ▶ WARN  KafkaMdm "mdm": failed to submit data: kafka: Failed to deliver 56 messages. will try again in 100ms. (this attempt took 1.18880466s)
11:37:06.769657 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.769694 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.769717 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.769741 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.769781 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.769808 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.769833 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.769856 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.769880 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.769905 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.769930 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.769962 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.769992 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770016 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770040 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770090 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770115 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770151 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770179 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770209 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770235 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770259 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770288 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770320 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770345 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770371 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770395 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770420 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770445 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770479 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770516 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770542 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770567 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770591 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770615 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770639 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770663 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770688 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770712 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770748 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770772 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770798 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770834 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770868 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770894 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770919 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770942 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770966 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.770995 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.771030 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.771057 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.771081 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.771107 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.771131 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.771164 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.771190 ▶ ERRO  Write to kafka failed: %!(EXTRA *sarama.ProducerError=kafka: Failed to produce message to topic mdm: dial tcp: lookup bfaca833d8e4 on 127.0.1.1:53: no such host)
11:37:06.771218 ▶ WARN  KafkaMdm "mdm": failed to submit data: kafka: Failed to deliver 56 messages. will try again in 100ms. (this attempt took 1.187441272s)

```