### PR TITLE
unrouteable messages should be debug not notice

### DIFF
--- a/examples/carbon-relay-ng.ini
+++ b/examples/carbon-relay-ng.ini
@@ -10,7 +10,8 @@ spool_dir = "spool"
 pid_file = "carbon-relay-ng.pid"
 
 ## Logging ##
-#one of critical error warning notice info debug
+# one of critical error warning notice info debug
+# see docs/logging.md for level descriptions
 log_level = "notice"
 
 ## Validation of inputs ##

--- a/table/table.go
+++ b/table/table.go
@@ -119,7 +119,7 @@ func (table *Table) Dispatch(buf []byte) {
 
 	if !routed {
 		table.numUnroutable.Inc(1)
-		log.Notice("unrouteable: %s\n", final)
+		log.Info("unrouteable: %s\n", final)
 	}
 }
 
@@ -139,7 +139,7 @@ func (table *Table) DispatchAggregate(buf []byte) {
 
 	if !routed {
 		table.numUnroutable.Inc(1)
-		log.Notice("unrouteable: %s\n", buf)
+		log.Info("unrouteable: %s\n", buf)
 	}
 
 }


### PR DESCRIPTION
for some people these messages are annoying, when you deliberately
don't want to route all your inputs (e.g. you use aggregators
and only forward the aggregation output)