### PR TITLE
rewrite before aggregator; fix race condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Note:
   - aggregation of individual metrics, i.e. packets for the same key, with different timestamps.  For example if you receive values for the same key every second, you can aggregate into minutely buckets by setting interval to 60, and have the fmt yield a unique key for every input metric key.  (~ graphite rollups)
   - the combination: compute aggregates from values seen with different keys, and at multiple points in time.
 * functions currently available: avg, delta, last, max, min, stdev, sum
-* aggregation output is routed via the routing table just like all other metrics.  Note that aggregation output will never go back into aggregators (to prevent loops) and also bypasses the validation and blacklist.
+* aggregation output is routed via the routing table just like all other metrics.  Note that aggregation output will never go back into aggregators (to prevent loops) and also bypasses the validation and blacklist and rewriters.
 * see the included ini for examples
 
 Rewriting

--- a/table/table.go
+++ b/table/table.go
@@ -94,15 +94,15 @@ func (table *Table) Dispatch(buf []byte) {
 		}
 	}
 
+	for _, rw := range conf.rewriters {
+		fields[0] = rw.Do(fields[0])
+	}
+
 	for _, aggregator := range conf.aggregators {
 		// we rely on incoming metrics already having been validated
 		if aggregator.PreMatch(fields[0]) {
 			aggregator.In <- fields
 		}
-	}
-
-	for _, rw := range conf.rewriters {
-		fields[0] = rw.Do(fields[0])
 	}
 
 	final := bytes.Join(fields, []byte(" "))


### PR DESCRIPTION
it should always have been blacklist -> rewriter -> aggregator
that's also how it's documented.
in particular, this also fixes a race condition that may have caused bad
stats:
before this fix,
table sends a slice with the metric fields (key etc) to aggregator on a
channel, then invokes the rewriter which modifies the value in the first
slot of the array. when the aggregator reads field 0 (metric key) it is
concurrent with the rewriter modifying it, so the key seen might be pre
or post rewriting, and this is also confirmed via the race detector.

worse, this also caused panics when the key being changed caused the
regex expansion in the aggregator regex stuff to not find the needed
matching groups as shown in #197