### PR TITLE
bugfix: make init section work again. fix #201

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -13,7 +13,7 @@ type Config struct {
 	Amqp                    Amqp
 	Max_procs               int
 	First_only              bool
-	Init                    []string
+	Init                    Init
 	Instance                string
 	Log_level               string
 	Instrumentation         instrumentation
@@ -84,6 +84,10 @@ type Amqp struct {
 	Amqp_key       string
 	Amqp_durable   bool
 	Amqp_exclusive bool
+}
+
+type Init struct {
+	Cmds []string
 }
 
 type instrumentation struct {

--- a/examples/carbon-relay-ng.ini
+++ b/examples/carbon-relay-ng.ini
@@ -130,13 +130,12 @@ addr = 'your-base-url/metrics'
 apikey = 'your-grafana.net-api-key'
 schemasFile = 'examples/storage-schemas.conf'
 
-## Init commands ###
+[init]
 # you can also put init commands here, in the same format as you'd use for the telnet interface
-# here are some examples.  The current thinking is to deprecate this format in favor of the more
-# structured config sections above.  As these commands are a bit clunky, people trip over the 
-# double spaces in some cases, etc.
-# let me know what you think on https://github.com/graphite-ng/carbon-relay-ng/pull/183
-init = [
+# (which is a bit tricky to use with its double spaces etc, so you're typically better off defining
+# your setup via the sections above)
+# here are some examples:
+cmds = [
      # a plain carbon route that sends all data to the specified carbon (graphite) server (note the double space)
      #'addRoute sendAllMatch carbon-default  your-graphite-server:2003 spool=true pickle=false',
 

--- a/table/table.go
+++ b/table/table.go
@@ -498,7 +498,7 @@ func InitFromConfig(config cfg.Config) (*Table, error) {
 }
 
 func (table *Table) InitCmd(config cfg.Config) error {
-	for i, cmd := range config.Init {
+	for i, cmd := range config.Init.Cmds {
 		log.Notice("applying: %s", cmd)
 		err := imperatives.Apply(table, cmd)
 		if err != nil {


### PR DESCRIPTION
In between 0.8.7 and 0.8.8 (1) the init commands were moved to the bottom of
the example config parser, where the config parser assumed they were
part of a named section and would recognize them anymore properly.
Now the section has its own named header so that it is always properly
recognized.

(1) aacf1d80151abd912874097c36d940941b2026e7