### PR TITLE
make blocking/nonblocking controllable per route

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -51,6 +51,7 @@ type Route struct {
 	FlushMaxNum  int
 	FlushMaxWait int
 	Timeout      int
+	Blocking     bool
 
 	// grafanaNet
 	Addr        string

--- a/destination/conn.go
+++ b/destination/conn.go
@@ -47,6 +47,7 @@ type Conn struct {
 	tickFlushSize     metrics.Histogram // only updated after successful flush. in bytes
 	manuFlushSize     metrics.Histogram // only updated after successful flush. in bytes
 	numBuffered       metrics.Gauge
+	bufferSize        metrics.Gauge
 	numDropBadPickle  metrics.Counter
 }
 
@@ -85,8 +86,10 @@ func NewConn(addr string, dest *Destination, periodFlush time.Duration, pickle b
 		tickFlushSize:     stats.Histogram("dest=" + cleanAddr + ".unit=B.what=FlushSize.type=ticker"),
 		manuFlushSize:     stats.Histogram("dest=" + cleanAddr + ".unit=B.what=FlushSize.type=manual"),
 		numBuffered:       stats.Gauge("dest=" + cleanAddr + ".unit=Metric.what=numBuffered"),
+		bufferSize:        stats.Gauge("dest=" + cleanAddr + ".unit=Metric.what=bufferSize"),
 		numDropBadPickle:  stats.Counter("dest=" + cleanAddr + ".unit=Metric.action=drop.reason=bad_pickle"),
 	}
+	connObj.bufferSize.Update(int64(connBufSize))
 
 	go connObj.checkEOF()
 

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -1,0 +1,74 @@
+# routes
+
+## carbon route
+
+setting        | mandatory | values                                        | default | description 
+---------------|-----------|-----------------------------------------------|---------|------------
+key            |     Y     | string                                        | N/A     |
+type           |     Y     | sendAllMatch/sendFirstMatch/consistentHashing | N/A     | send to all destinations vs first matching destination vs distribute via consistent hashing
+prefix         |     N     | string                                        | ""      |
+sub            |     N     | string                                        | ""      |
+regex          |     N     | string                                        | ""      |
+
+## carbon destination
+
+setting              | mandatory | values        | default | description 
+---------------------|-----------|---------------|---------|------------
+addr                 |     Y     |  string       | N/A     |
+prefix               |     N     |  string       | ""      |
+sub                  |     N     |  string       | ""      |
+regex                |     N     |  string       | ""      |
+flush                |     N     |  int (ms)     | 1000    | flush interval
+reconn               |     N     |  int (ms)     | 10k     | reconnection interval
+pickle               |     N     |  true/false   | false   | pickle output format instead of the default text protocol
+spool                |     N     |  true/false   | false   | disk spooling
+connbuf              |     N     |  int          | 30k     | connection buffer (how many metrics can be queued, not written into network conn)
+iobuf                |     N     |  int (bytes)  | 2M      | buffered io connection buffer
+spoolbuf             |     N     |  int          | 10k     | num of metrics to buffer across disk-write stalls. practically, tune this to number of metrics in a second
+spoolmaxbytesperfile |     N     |  int          | 200MiB  | max filesize for spool files
+spoolsyncevery       |     N     |  int          | 10k     | sync spool to disk every this many metrics
+spoolsyncperiod      |     N     |  int  (ms)    | 1000    | sync spool to disk every this many milliseconds
+spoolsleep           |     N     |  int (micros) | 500     | sleep this many microseconds(!) in between ingests from bulkdata/redo buffers into spool
+unspoolsleep         |     N     |  int (micros) | 10      | sleep this many microseconds(!) in between reads from the spool, when replaying spooled data
+
+## grafanaNet route
+
+setting        | mandatory | values      | default | description 
+---------------|-----------|-------------|---------|------------
+key            |     Y     |  string     | N/A     |
+addr           |     Y     |  string     | N/A     |
+apiKey         |     Y     |  string     | N/A     |
+schemasFile    |     Y     |  string     | N/A     |
+prefix         |     N     |  string     | ""      |
+sub            |     N     |  string     | ""      |
+regex          |     N     |  string     | ""      |
+sslverify      |     N     |  true/false | true    |
+spool          |     N     |  true/false | false   | ** disk spooling. not implemented yet **
+blocking       |     N     |  true/false | false   | if false, full buffer drops data. if true, full buffer puts backpressure on the table, possibly affecting ingestion and other routes
+concurrency    |     N     |  int        | 10      | number of concurrent connections to ingestion endpoint
+bufSize        |     N     |  int        | 10M     | buffer size. assume +- 100B per message, so 10M is about 1GB of RAM
+flushMaxNum    |     N     |  int        | 10k     | max number of metrics to buffer before triggering flush
+flushMaxWait   |     N     |  int (ms)   | 500     | max time to buffer before triggering flush
+timeout        |     N     |  int (ms)   | 5000    | abort and retry requests to api gateway if takes longer than this.
+orgId          |     N     |  int        | 1       |
+
+## kafkaMdm route
+
+setting        | mandatory | values      | default | description 
+---------------|-----------|-------------|---------|------------
+key            |     Y     |  string     | N/A     |
+brokers        |     Y     |  []string   | N/A     |
+topic          |     Y     |  string     | N/A     |
+codec          |     Y     |  string     | N/A     |
+partitionBy    |     Y     |  string     | N/A     |
+schemasFile    |     Y     |  string     | N/A     |
+prefix         |     N     |  string     | ""      |
+sub            |     N     |  string     | ""      |
+regex          |     N     |  string     | ""      |
+blocking       |     N     |  true/false | false   | if false, full buffer drops data. if true, full buffer puts backpressure on the table, possibly affecting ingestion and other routes
+bufSize        |     N     |  int        | 10M     | buffer size. assume +- 100B per message, so 10M is about 1GB of RAM
+flushMaxNum    |     N     |  int        | 10k     | max number of metrics to buffer before triggering flush
+flushMaxWait   |     N     |  int (ms)   | 500     | max time to buffer before triggering flush
+timeout        |     N     |  int (ms)   | 2000    |
+orgId          |     N     |  int        | 1       |
+

--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -511,15 +511,24 @@
             "total": false,
             "values": false
           },
-          "lines": true,
+          "lines": false,
           "linewidth": 1,
           "links": [],
           "nullPointMode": "connected",
           "percentage": false,
-          "pointradius": 5,
-          "points": false,
+          "pointradius": 2,
+          "points": true,
           "renderer": "flot",
-          "seriesOverrides": [],
+          "seriesOverrides": [
+            {
+              "alias": "/bufferSize/",
+              "color": "#890F02",
+              "fill": 0,
+              "lines": true,
+              "linewidth": 3,
+              "points": false
+            }
+          ],
           "span": 4,
           "stack": false,
           "steppedLine": false,
@@ -527,6 +536,10 @@
             {
               "refId": "A",
               "target": "alias(service_is_carbon-relay-ng.instance_is_$instance.mtype_is_gauge.dest_is_$dest.unit_is_Metric.what_is_numBuffered, 'numBuffered')"
+            },
+            {
+              "refId": "B",
+              "target": "alias(service_is_carbon-relay-ng.instance_is_$instance.mtype_is_gauge.dest_is_$dest.unit_is_Metric.what_is_bufferSize, 'bufferSize')"
             }
           ],
           "timeFrom": null,

--- a/imperatives/imperatives.go
+++ b/imperatives/imperatives.go
@@ -40,6 +40,7 @@ const (
 	num
 	optPrefix
 	optAddr
+	optBlocking
 	optSub
 	optRegex
 	optFlush
@@ -84,6 +85,7 @@ var tokens = []toki.Def{
 	{Token: modRoute, Pattern: "modRoute"},
 	{Token: optPrefix, Pattern: "prefix="},
 	{Token: optAddr, Pattern: "addr="},
+	{Token: optBlocking, Pattern: "blocking="},
 	{Token: optSub, Pattern: "sub="},
 	{Token: optRegex, Pattern: "regex="},
 	{Token: optFlush, Pattern: "flush="},
@@ -125,8 +127,8 @@ var tokens = []toki.Def{
 var errFmtAddBlack = errors.New("addBlack <prefix|sub|regex> <pattern>")
 var errFmtAddAgg = errors.New("addAgg <avg|delta|last|max|min|stdev|sum> <regex> <fmt> <interval> <wait>")
 var errFmtAddRoute = errors.New("addRoute <type> <key> [prefix/sub/regex=,..]  <dest>  [<dest>[...]] where <dest> is <addr> [prefix/sub,regex,flush,reconn,pickle,spool=...]") // note flush and reconn are ints, pickle and spool are true/false. other options are strings
-var errFmtAddRouteGrafanaNet = errors.New("addRoute grafanaNet key [prefix/sub/regex]  addr apiKey schemasFile [spool=true/false sslverify=true/false bufSize=int flushMaxNum=int flushMaxWait=int timeout=int concurrency=int orgId=int]")
-var errFmtAddRouteKafkaMdm = errors.New("addRoute kafkaMdm key [prefix/sub/regex]  broker topic codec schemasFile partitionBy orgId [bufSize=int flushMaxNum=int flushMaxWait=int timeout=int]")
+var errFmtAddRouteGrafanaNet = errors.New("addRoute grafanaNet key [prefix/sub/regex]  addr apiKey schemasFile [spool=true/false sslverify=true/false blocking=true/false bufSize=int flushMaxNum=int flushMaxWait=int timeout=int concurrency=int orgId=int]")
+var errFmtAddRouteKafkaMdm = errors.New("addRoute kafkaMdm key [prefix/sub/regex]  broker topic codec schemasFile partitionBy orgId [blocking=true/false bufSize=int flushMaxNum=int flushMaxWait=int timeout=int]")
 var errFmtAddDest = errors.New("addDest <routeKey> <dest>") // not implemented yet
 var errFmtAddRewriter = errors.New("addRewriter <old> <new> <max>")
 var errFmtModDest = errors.New("modDest <routeKey> <dest> <addr/prefix/sub/regex=>") // one or more can be specified at once
@@ -342,7 +344,7 @@ func readAddRouteGrafanaNet(s *toki.Scanner, table Table) error {
 	schemasFile := string(t.Value)
 	t = s.Next()
 
-	var spool bool
+	var spool, blocking bool
 	sslVerify := true
 	var bufSize = int(1e7)  // since a message is typically around 100B this is 1GB
 	var flushMaxNum = 10000 // number of metrics
@@ -353,6 +355,16 @@ func readAddRouteGrafanaNet(s *toki.Scanner, table Table) error {
 
 	for ; t.Token != toki.EOF; t = s.Next() {
 		switch t.Token {
+		case optBlocking:
+			t = s.Next()
+			if t.Token == optTrue || t.Token == optFalse {
+				blocking, err = strconv.ParseBool(string(t.Value))
+				if err != nil {
+					return err
+				}
+			} else {
+				return errFmtAddRouteGrafanaNet
+			}
 		case optSpool:
 			t = s.Next()
 			if t.Token == optTrue || t.Token == optFalse {
@@ -438,7 +450,7 @@ func readAddRouteGrafanaNet(s *toki.Scanner, table Table) error {
 		}
 	}
 
-	route, err := route.NewGrafanaNet(key, prefix, sub, regex, addr, apiKey, schemasFile, spool, sslVerify, bufSize, flushMaxNum, flushMaxWait, timeout, concurrency, orgId)
+	route, err := route.NewGrafanaNet(key, prefix, sub, regex, addr, apiKey, schemasFile, spool, sslVerify, blocking, bufSize, flushMaxNum, flushMaxWait, timeout, concurrency, orgId)
 	if err != nil {
 		return err
 	}
@@ -506,10 +518,21 @@ func readAddRouteKafkaMdm(s *toki.Scanner, table Table) error {
 	var flushMaxNum = 10000 // number of metrics
 	var flushMaxWait = 500  // in ms
 	var timeout = 2000      // in ms
+	var blocking = false
 
 	t = s.Next()
 	for ; t.Token != toki.EOF; t = s.Next() {
 		switch t.Token {
+		case optBlocking:
+			t = s.Next()
+			if t.Token == optTrue || t.Token == optFalse {
+				blocking, err = strconv.ParseBool(string(t.Value))
+				if err != nil {
+					return err
+				}
+			} else {
+				return errFmtAddRouteKafkaMdm
+			}
 		case optBufSize:
 			t = s.Next()
 			if t.Token == num {
@@ -555,7 +578,7 @@ func readAddRouteKafkaMdm(s *toki.Scanner, table Table) error {
 		}
 	}
 
-	route, err := route.NewKafkaMdm(key, prefix, sub, regex, topic, codec, schemasFile, partitionBy, brokers, bufSize, orgId, flushMaxNum, flushMaxWait, timeout)
+	route, err := route.NewKafkaMdm(key, prefix, sub, regex, topic, codec, schemasFile, partitionBy, brokers, bufSize, orgId, flushMaxNum, flushMaxWait, timeout, blocking)
 	if err != nil {
 		return err
 	}

--- a/route/dispatch.go
+++ b/route/dispatch.go
@@ -4,11 +4,12 @@ import "github.com/Dieterbe/go-metrics"
 
 // DispatchNonBlocking will dispatch in to buf.
 // if buf is full, will discard the data
-func dispatchNonBlocking(buf chan []byte, in []byte, gauge metrics.Gauge) {
+func dispatchNonBlocking(buf chan []byte, in []byte, gauge metrics.Gauge, drops metrics.Counter) {
 	select {
 	case buf <- in:
 		gauge.Inc(1)
 	default:
+		drops.Inc(1)
 	}
 }
 
@@ -16,7 +17,7 @@ func dispatchNonBlocking(buf chan []byte, in []byte, gauge metrics.Gauge) {
 // If buf is full, the call will block
 // note that in this case, numBuffered will contain size of buffer + number of waiting entries,
 // and hence could be > bufSize
-func dispatchBlocking(buf chan []byte, in []byte, gauge metrics.Gauge) {
+func dispatchBlocking(buf chan []byte, in []byte, gauge metrics.Gauge, drops metrics.Counter) {
 	gauge.Inc(1)
 	buf <- in
 }

--- a/route/dispatch.go
+++ b/route/dispatch.go
@@ -1,0 +1,22 @@
+package route
+
+import "github.com/Dieterbe/go-metrics"
+
+// DispatchNonBlocking will dispatch in to buf.
+// if buf is full, will discard the data
+func dispatchNonBlocking(buf chan []byte, in []byte, gauge metrics.Gauge) {
+	select {
+	case buf <- in:
+		gauge.Inc(1)
+	default:
+	}
+}
+
+// DispatchBlocking will dispatch in to buf.
+// If buf is full, the call will block
+// note that in this case, numBuffered will contain size of buffer + number of waiting entries,
+// and hence could be > bufSize
+func dispatchBlocking(buf chan []byte, in []byte, gauge metrics.Gauge) {
+	gauge.Inc(1)
+	buf <- in
+}

--- a/route/grafananet.go
+++ b/route/grafananet.go
@@ -52,6 +52,7 @@ type GrafanaNet struct {
 	tickFlushSize     metrics.Histogram // only updated after successful flush
 	manuFlushSize     metrics.Histogram // only updated after successful flush. not implemented yet
 	numBuffered       metrics.Gauge
+	bufferSize        metrics.Gauge
 }
 
 // NewGrafanaNet creates a special route that writes to a grafana.net datastore
@@ -95,8 +96,11 @@ func NewGrafanaNet(key, prefix, sub, regex, addr, apiKey, schemasFile string, sp
 		tickFlushSize:     stats.Histogram("dest=" + cleanAddr + ".unit=B.what=FlushSize.type=ticker"),
 		manuFlushSize:     stats.Histogram("dest=" + cleanAddr + ".unit=B.what=FlushSize.type=manual"),
 		numBuffered:       stats.Gauge("dest=" + cleanAddr + ".unit=Metric.what=numBuffered"),
+		bufferSize:        stats.Gauge("dest=" + cleanAddr + ".unit=Metric.what=bufferSize"),
 		numDropBuffFull:   stats.Counter("dest=" + cleanAddr + ".unit=Metric.action=drop.reason=queue_full"),
 	}
+
+	r.bufferSize.Update(int64(bufSize))
 
 	if blocking {
 		r.dispatch = dispatchBlocking

--- a/route/kafkamdm.go
+++ b/route/kafkamdm.go
@@ -44,6 +44,7 @@ type KafkaMdm struct {
 	tickFlushSize     metrics.Histogram // only updated after successful flush
 	manuFlushSize     metrics.Histogram // only updated after successful flush. not implemented yet
 	numBuffered       metrics.Gauge
+	bufferSize        metrics.Gauge
 }
 
 // NewKafkaMdm creates a special route that writes to a grafana.net datastore
@@ -80,8 +81,10 @@ func NewKafkaMdm(key, prefix, sub, regex, topic, codec, schemasFile, partitionBy
 		tickFlushSize:     stats.Histogram("dest=" + cleanAddr + ".unit=B.what=FlushSize.type=ticker"),
 		manuFlushSize:     stats.Histogram("dest=" + cleanAddr + ".unit=B.what=FlushSize.type=manual"),
 		numBuffered:       stats.Gauge("dest=" + cleanAddr + ".unit=Metric.what=numBuffered"),
+		bufferSize:        stats.Gauge("dest=" + cleanAddr + ".unit=Metric.what=bufferSize"),
 		numDropBuffFull:   stats.Counter("dest=" + cleanAddr + ".unit=Metric.action=drop.reason=queue_full"),
 	}
+	r.bufferSize.Update(int64(bufSize))
 
 	if blocking {
 		r.dispatch = dispatchBlocking

--- a/table/table.go
+++ b/table/table.go
@@ -658,7 +658,7 @@ func (table *Table) InitRoutes(config cfg.Config) error {
 				orgId = routeConfig.OrgId
 			}
 
-			route, err := route.NewGrafanaNet(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, routeConfig.Addr, routeConfig.ApiKey, routeConfig.SchemasFile, spool, sslVerify, bufSize, flushMaxNum, flushMaxWait, timeout, concurrency, orgId)
+			route, err := route.NewGrafanaNet(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, routeConfig.Addr, routeConfig.ApiKey, routeConfig.SchemasFile, spool, sslVerify, routeConfig.Blocking, bufSize, flushMaxNum, flushMaxWait, timeout, concurrency, orgId)
 			if err != nil {
 				log.Error(err.Error())
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)
@@ -687,7 +687,7 @@ func (table *Table) InitRoutes(config cfg.Config) error {
 				timeout = routeConfig.Timeout
 			}
 
-			route, err := route.NewKafkaMdm(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, routeConfig.Topic, routeConfig.Codec, routeConfig.SchemasFile, routeConfig.PartitionBy, routeConfig.Brokers, bufSize, routeConfig.OrgId, flushMaxNum, flushMaxWait, timeout)
+			route, err := route.NewKafkaMdm(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, routeConfig.Topic, routeConfig.Codec, routeConfig.SchemasFile, routeConfig.PartitionBy, routeConfig.Brokers, bufSize, routeConfig.OrgId, flushMaxNum, flushMaxWait, timeout, routeConfig.Blocking)
 			if err != nil {
 				log.Error(err.Error())
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)


### PR DESCRIPTION
(currently only implemented for kafkaMdm/grafanaNet routes)

A route can behave in two ways:
1) blocking: if it cannot ingest any more metrics (e.g.
   remote endpoint is down or too slow, and the route has no
   internal buffer, or the buffer is full) the route can block
   its Dispatch() call, effectively blocking the table,
   providing valuable feedback to clients sending data into
   the relay via backpressure, but in the process also
   preventing other routes from getting any inputs,
   since the table is blocked.
2) non-blocking: if it cannot ingest any more metrics, it can
   just discard metrics, returning Dispatch() early,
   so that the table keeps running (servicing any other routes
   that may be active and healthy)
   and clients sending data into the relay are none the wiser.

historically, all carbon routes were (and still are) non-blocking.
The assumption was you always had multiple routes and when one had
trouble it was never a reason to block any other routes.
There's a chance for data loss, but is mitigated via spooling and
the metrics buffer.
The kafkaMdm route also has a buffer and non-blocking dispatching.

Now we're more commonly seeing setups that have only 1 route,
so it makes more sense to provide backpressure
(and blocking the table in the process), to minimize data loss
- though only if you have smart clients that can deal with this.
The grafanaNet route actually is blocking, in contrast to
all other routes/destinations (including kafkaMdm).
Notably if you use >1 grafanaNet routes you can block the table when
buffer runs full. see #167

I think the best solution is to support both modes and leave the
configuration up to the user. They can choose the desired behavior
based on how many routes they have, and whether the clients can
deal with backpressure.

