### PR TITLE
New aggregator: rate calculation aggregation (#207)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,4 +134,4 @@ run: build
 run-docker:
 	docker run --rm -p 2003:2003 -p 2004:2004 -p 8081:8081 -v $(pwd)/examples:/conf -v $(pwd)/spool:/spool raintank/carbon-relay-ng
 
-.PHONY: all deb gh-pages install man test
+.PHONY: all deb gh-pages install man test build

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -4,75 +4,73 @@ import (
 	"testing"
 )
 
+type AggCase map[string]float64
+
+type TestCase struct {
+	in  []float64
+	ts  []uint
+	agg AggCase
+}
+
+var AllTestCases = []TestCase{
+	{
+		in: []float64{5, 4, 7, 4, 2, 5, 4, 9},
+		ts: []uint{1, 2, 3, 4, 5, 6, 7, 8},
+		agg: AggCase{
+			"avg":   5,
+			"delta": 7,
+			"last":  9,
+			"max":   9,
+			"min":   2,
+			"stdev": 2,
+			"sum":   40,
+			"rate":  0.5714285714285714,
+		},
+	},
+	{
+		in: []float64{6, 2, 3, 1},
+		ts: []uint{1, 2, 3, 4},
+		agg: AggCase{
+			"avg":   3,
+			"delta": 5,
+			"last":  1,
+			"max":   6,
+			"min":   1,
+			"stdev": 1.8708286933869707,
+			"sum":   12,
+			"rate":  -1.6666666666666667,
+		},
+	},
+	/* FIXME(gautran): Out of order metrics don't get handled properly
+	{ // Test receiving metric out of order
+		in: []float64{5, 4, 7, 4, 2, 5, 9, 4},
+		ts: []uint{1, 2, 3, 4, 5, 6, 8, 7},
+		agg: AggCase{
+			"avg":   5,
+			"delta": 7,
+			"last":  9,
+			"max":   9,
+			"min":   2,
+			"stdev": 2,
+			"sum":   40,
+			"rate":  0.5714285714285714,
+		},
+	},
+	*/
+}
+
 func TestScanner(t *testing.T) {
-	cases := []struct {
-		in    []float64
-		avg   float64
-		delta float64
-		last  float64
-		max   float64
-		min   float64
-		stdev float64
-		sum   float64
-	}{
-		{
-			[]float64{5, 4, 7, 4, 2, 5, 4, 9},
-			5,
-			7,
-			9,
-			9,
-			2,
-			2,
-			40,
-		},
-		{
-			[]float64{6, 2, 3, 1},
-			3,
-			5,
-			1,
-			6,
-			1,
-			1.8708286933869707,
-			12,
-		},
+
+	log.Info("In the test scanner method")
+
+	for i := range AllTestCases {
+		test := AllTestCases[i]
+		for agg, expected := range test.agg {
+			actual := Funcs[agg](test.in, test.ts)
+			if actual != expected {
+				t.Fatalf("case %s - expected %v, actual %v", agg, expected, actual)
+			}
+		}
 	}
-	for i, e := range cases {
-		var actual float64
 
-		actual = Avg(e.in)
-		if actual != e.avg {
-			t.Fatalf("case %d AVG - expected %v, actual %v", i, e.avg, actual)
-		}
-
-		actual = Delta(e.in)
-		if actual != e.delta {
-			t.Fatalf("case %d DELTA - expected %v, actual %v", i, e.delta, actual)
-		}
-
-		actual = Last(e.in)
-		if actual != e.last {
-			t.Fatalf("case %d LAST - expected %v, actual %v", i, e.last, actual)
-		}
-
-		actual = Max(e.in)
-		if actual != e.max {
-			t.Fatalf("case %d MAX - expected %v, actual %v", i, e.max, actual)
-		}
-
-		actual = Min(e.in)
-		if actual != e.min {
-			t.Fatalf("case %d MIN - expected %v, actual %v", i, e.min, actual)
-		}
-
-		actual = Stdev(e.in)
-		if actual != e.stdev {
-			t.Fatalf("case %d STDEV - expected %v, actual %v", i, e.stdev, actual)
-		}
-
-		actual = Sum(e.in)
-		if actual != e.sum {
-			t.Fatalf("case %d SUM - expected %v, actual %v", i, e.sum, actual)
-		}
-
-	}
 }

--- a/imperatives/imperatives.go
+++ b/imperatives/imperatives.go
@@ -35,6 +35,7 @@ const (
 	lastFn
 	maxFn
 	minFn
+	rateFn
 	stdevFn
 	sumFn
 	num
@@ -116,6 +117,7 @@ var tokens = []toki.Def{
 	{Token: lastFn, Pattern: "last "},
 	{Token: deltaFn, Pattern: "delta "},
 	{Token: stdevFn, Pattern: "stdev "},
+	{Token: rateFn, Pattern: "rate "},
 	{Token: num, Pattern: "[0-9]+( |$)"}, // unfortunately we need the 2nd piece cause otherwise it would match the first of ip addresses etc. this means we need to TrimSpace later
 	{Token: word, Pattern: "[^ ]+"},
 }
@@ -123,7 +125,7 @@ var tokens = []toki.Def{
 // note the two spaces between a route and endpoints
 // match options can't have spaces for now. sorry
 var errFmtAddBlack = errors.New("addBlack <prefix|sub|regex> <pattern>")
-var errFmtAddAgg = errors.New("addAgg <avg|delta|last|max|min|stdev|sum> <regex> <fmt> <interval> <wait>")
+var errFmtAddAgg = errors.New("addAgg <avg|delta|last|max|min|rate|stdev|sum> <regex> <fmt> <interval> <wait>")
 var errFmtAddRoute = errors.New("addRoute <type> <key> [prefix/sub/regex=,..]  <dest>  [<dest>[...]] where <dest> is <addr> [prefix/sub,regex,flush,reconn,pickle,spool=...]") // note flush and reconn are ints, pickle and spool are true/false. other options are strings
 var errFmtAddRouteGrafanaNet = errors.New("addRoute grafanaNet key [prefix/sub/regex]  addr apiKey schemasFile [spool=true/false sslverify=true/false bufSize=int flushMaxNum=int flushMaxWait=int timeout=int concurrency=int orgId=int]")
 var errFmtAddRouteKafkaMdm = errors.New("addRoute kafkaMdm key [prefix/sub/regex]  broker topic codec schemasFile partitionBy orgId [bufSize=int flushMaxNum=int flushMaxWait=int timeout=int]")
@@ -178,10 +180,19 @@ func Apply(table Table, cmd string) error {
 	}
 }
 
+func tokenInSlice(a toki.Token, list []toki.Token) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
 func readAddAgg(s *toki.Scanner, table Table) error {
 	t := s.Next()
-	if t.Token != sumFn && t.Token != avgFn && t.Token != minFn && t.Token != maxFn && t.Token != lastFn && t.Token != deltaFn && t.Token != stdevFn {
-		return errors.New("invalid function. need avg/max/min/sum/last/delta/stdev")
+	if !tokenInSlice(t.Token, []toki.Token{sumFn, avgFn, minFn, maxFn, lastFn, deltaFn, stdevFn, rateFn}) {
+		return errors.New("invalid function. need avg/delta/last/max/min/rate/sum/stdev")
 	}
 	fun := string(t.Value[:len(t.Value)-1]) // strip trailing space
 

--- a/ui/telnet/telnet.go
+++ b/ui/telnet/telnet.go
@@ -64,6 +64,7 @@ commands:
                last
                max
                min
+               rate
                stdev
                sum
              <regex>                             regex to match incoming metrics. supports groups (numbered, see fmt)

--- a/ui/web/admin_http_assets/app.js
+++ b/ui/web/admin_http_assets/app.js
@@ -45,6 +45,9 @@ app.controller("MainCtl", ["$scope", "$resource", "$modal", function($scope, $re
               if (value == "min") {
                   return true;
               }
+              if (value == "rate") {
+                  return true;
+              }
               if (value == "stdev") {
                   return true;
               }

--- a/ui/web/admin_http_assets/index.html
+++ b/ui/web/admin_http_assets/index.html
@@ -161,7 +161,7 @@
                     <td class="form-group has-feedback">
                         <input ng-model="newAgg.Fun" name="fun" class="form-control" placeholder="Function" required ng-pattern="validAggFunc">
                         <div ng-show="aggForm.fun.$invalid">
-                            <span ng-show="aggForm.fun.$error.pattern">Expected aggregation function: avg, delta, last, max, min, stdev or sum</span>
+                            <span ng-show="aggForm.fun.$error.pattern">Expected aggregation function: avg, delta, last, max, min, rate, stdev or sum</span>
                         </div>
                     </td>
                     <td class="form-group has-feedback">

--- a/ui/web/bindata.go
+++ b/ui/web/bindata.go
@@ -105,7 +105,7 @@ func admin_http_assetsAppJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "admin_http_assets/app.js", size: 4723, mode: os.FileMode(436), modTime: time.Unix(1497368977, 0)}
+	info := bindataFileInfo{name: "admin_http_assets/app.js", size: 4723, mode: os.FileMode(436), modTime: time.Unix(1498182952, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -125,7 +125,7 @@ func admin_http_assetsIndexHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "admin_http_assets/index.html", size: 15423, mode: os.FileMode(436), modTime: time.Unix(1497369022, 0)}
+	info := bindataFileInfo{name: "admin_http_assets/index.html", size: 15423, mode: os.FileMode(436), modTime: time.Unix(1498182952, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
Create a new aggregator providing a rate of change for monotonic counters.
The aggregator work by computing the rate of change using the following formula:

```
rate = (Vnew - Vold)/(Tnew - Told)
```

Note:
The aggregator uses the actual timestamp (second precision) of the metric.
This means that if the aggregation window is larger than the number of samples, the rate should still be calculated properly.

Known Bugs:
The metrics values received are not re-ordered if received out of order. This has a limited impact if the time between metrics is slow (10s).

Issue: #207