### PR TITLE
Fix the creation of `/var/run/carbon-relay-ng` directory (#212)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /carbon-relay-ng.test
 test_spool
 spool/*.dat
+*~

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ deb: build
 		--description "Fast carbon relay+aggregator with admin interfaces for making changes online" \
 		--license BSD \
 		--url https://github.com/graphite-ng/carbon-relay-ng \
+		--after-install examples/after_install.sh \
 		-C debian .
 	rm -rf debian
 
@@ -82,6 +83,7 @@ rpm: build
 		--description "Fast carbon relay+aggregator with admin interfaces for making changes online" \
 		--license BSD \
 		--url https://github.com/graphite-ng/carbon-relay-ng \
+		--after-install examples/after_install.sh \
 		-C redhat .
 	rm -rf redhat
 
@@ -134,4 +136,4 @@ run: build
 run-docker:
 	docker run --rm -p 2003:2003 -p 2004:2004 -p 8081:8081 -v $(pwd)/examples:/conf -v $(pwd)/spool:/spool raintank/carbon-relay-ng
 
-.PHONY: all deb gh-pages install man test
+.PHONY: all deb gh-pages install man test build

--- a/examples/after_install.sh
+++ b/examples/after_install.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+
+setup_carbon_relay_user() {
+    if ! getent passwd carbon-relay-ng >/dev/null; then
+        adduser --quiet --system --group --no-create-home --home /var/run/carbon-relay-ng --shell /usr/sbin/nologin carbon-relay-ng
+    fi
+}
+
+
+# Create a carbon-relay-ng user if it does not already exists
+setup_carbon_relay_user

--- a/examples/carbon-relay-ng-tmpfiles.conf
+++ b/examples/carbon-relay-ng-tmpfiles.conf
@@ -1,2 +1,3 @@
 # Create tmp dir in /run, install into /usr/lib/tempfiles.d/
-d /run/carbon-relay-ng 0700 carbon-relay-ng carbon-relay-ng -
+#Type Path                 Mode UID             GID             Age Argument
+d     /run/carbon-relay-ng 0700 carbon-relay-ng carbon-relay-ng -   -

--- a/examples/carbon-relay-ng.ini
+++ b/examples/carbon-relay-ng.ini
@@ -122,13 +122,13 @@ destinations = [
   'graphite.staging:2003 prefix=staging. spool=true pickle=true'
 ]
 
-[[route]]
+#[[route]]
 # example route for https://grafana.com/cloud/metrics
-key = 'grafanaNet'
-type = 'grafanaNet'
-addr = 'your-base-url/metrics'
-apikey = 'your-grafana.net-api-key'
-schemasFile = 'examples/storage-schemas.conf'
+#key = 'grafanaNet'
+#type = 'grafanaNet'
+#addr = 'your-base-url/metrics'
+#apikey = 'your-grafana.net-api-key'
+#schemasFile = 'examples/storage-schemas.conf'
 
 [init]
 # you can also put init commands here, in the same format as you'd use for the telnet interface

--- a/examples/carbon-relay-ng.service
+++ b/examples/carbon-relay-ng.service
@@ -5,8 +5,8 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-User=root
-Group=root
+User=carbon-relay-ng
+Group=carbon-relay-ng
 Type=simple
 Restart=on-failure
 WorkingDirectory=/var/run/carbon-relay-ng

--- a/nsqd/diskqueue.go
+++ b/nsqd/diskqueue.go
@@ -78,8 +78,14 @@ func NewDiskQueue(name string, dataPath string, maxBytesPerFile int64, syncEvery
 		syncTimeout:       syncTimeout,
 	}
 
+	// Create the spool directory and all of its parents lazily
+	err := os.MkdirAll(d.dataPath, os.ModePerm)
+	if err != nil {
+		log.Printf("ERROR: diskqueue(%s) failed to make directory path:'%s' - %s", d.name, d.dataPath, err.Error())
+	}
+
 	// no need to lock here, nothing else could possibly be touching this instance
-	err := d.retrieveMetaData()
+	err = d.retrieveMetaData()
 	if err != nil && !os.IsNotExist(err) {
 		log.Printf("ERROR: diskqueue(%s) failed to retrieveMetaData - %s", d.name, err.Error())
 	}

--- a/ui/web/bindata.go
+++ b/ui/web/bindata.go
@@ -105,7 +105,7 @@ func admin_http_assetsAppJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "admin_http_assets/app.js", size: 4723, mode: os.FileMode(436), modTime: time.Unix(1497368977, 0)}
+	info := bindataFileInfo{name: "admin_http_assets/app.js", size: 4723, mode: os.FileMode(436), modTime: time.Unix(1503601526, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -125,7 +125,7 @@ func admin_http_assetsIndexHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "admin_http_assets/index.html", size: 15423, mode: os.FileMode(436), modTime: time.Unix(1497369022, 0)}
+	info := bindataFileInfo{name: "admin_http_assets/index.html", size: 15423, mode: os.FileMode(436), modTime: time.Unix(1503601526, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
Fix tmpfiles directory ownership