### PR TITLE
Parse tags in metric names

### DIFF
--- a/route/schemas.go
+++ b/route/schemas.go
@@ -71,7 +71,7 @@ func parseMetric(buf []byte, schemas persister.WhisperSchemas, orgId int) (*sche
 		Unit:     "unknown",
 		Time:     int64(timestamp),
 		Mtype:    "gauge",
-		Tags:     []string{},
+		Tags:     strings.Split(name, ";")[1:],
 		OrgId:    orgId,
 	}
 	return &md, nil

--- a/route/schemas_test.go
+++ b/route/schemas_test.go
@@ -47,3 +47,26 @@ func TestParseMetricWithTags(t *testing.T) {
 		t.Fatalf("Returned MetricData is not as expected:\nGot:\n%+v\nExpected:\n%+v\n", md, expectedMd)
 	}
 }
+
+func TestParseMetricWithoutTags(t *testing.T) {
+	schemas := getMatchEverythingSchemas()
+	time := int64(200)
+	value := float64(100)
+	name := "a.b.c"
+	line := []byte(fmt.Sprintf("%s %f %d", name, value, time))
+	md, _ := parseMetric(line, schemas, 1)
+	expectedMd := &schema.MetricData{
+		Name:     name,
+		Metric:   name,
+		Interval: 10,
+		Value:    value,
+		Unit:     "unknown",
+		Time:     time,
+		Mtype:    "gauge",
+		Tags:     []string{},
+		OrgId:    1,
+	}
+	if !reflect.DeepEqual(md, expectedMd) {
+		t.Fatalf("Returned MetricData is not as expected:\nGot:\n%+v\nExpected:\n%+v\n", md, expectedMd)
+	}
+}

--- a/route/schemas_test.go
+++ b/route/schemas_test.go
@@ -1,0 +1,49 @@
+package route
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/lomik/go-carbon/persister"
+	"gopkg.in/raintank/schema.v1"
+)
+
+func getMatchEverythingSchemas() persister.WhisperSchemas {
+	schema := persister.WhisperSchemas{
+		persister.Schema{
+			Name:         "everything",
+			RetentionStr: "10:8640",
+			Priority:     10,
+		},
+	}
+	schema[0].Retentions, _ = persister.ParseRetentionDefs(schema[0].RetentionStr)
+	schema[0].Pattern, _ = regexp.Compile(".*")
+	return schema
+}
+
+func TestParseMetricWithTags(t *testing.T) {
+	schemas := getMatchEverythingSchemas()
+	tags := []string{"tag1=value1", "tag2=value2"}
+	time := int64(200)
+	value := float64(100)
+	name := fmt.Sprintf("a.b.c;%s", strings.Join(tags, ";"))
+	line := []byte(fmt.Sprintf("%s %f %d", name, value, time))
+	md, _ := parseMetric(line, schemas, 1)
+	expectedMd := &schema.MetricData{
+		Name:     name,
+		Metric:   name,
+		Interval: 10,
+		Value:    value,
+		Unit:     "unknown",
+		Time:     time,
+		Mtype:    "gauge",
+		Tags:     tags,
+		OrgId:    1,
+	}
+	if !reflect.DeepEqual(md, expectedMd) {
+		t.Fatalf("Returned MetricData is not as expected:\nGot:\n%+v\nExpected:\n%+v\n", md, expectedMd)
+	}
+}


### PR DESCRIPTION
This is required to support metric tagging. It parses tags out of names and fills them into the metric definition.