### PR TITLE
measure memory used by carbon-relay-ng

### DIFF
--- a/cmd/carbon-relay-ng/carbon-relay-ng.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng.go
@@ -141,6 +141,17 @@ func main() {
 
 	input.InitMetrics()
 
+	go func() {
+		sys := stats.Gauge("what=virtual_memory.unit=Byte")
+		ticker := time.NewTicker(time.Second)
+		var memstats runtime.MemStats
+		for range ticker.C {
+			runtime.ReadMemStats(&memstats)
+			sys.Update(int64(memstats.Sys))
+
+		}
+	}()
+
 	if config.Instrumentation.Graphite_addr != "" {
 		addr, err := net.ResolveTCPAddr("tcp", config.Instrumentation.Graphite_addr)
 		if err != nil {

--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -527,6 +527,13 @@
               "lines": true,
               "linewidth": 3,
               "points": false
+            },
+            {
+              "alias": "memory-usage",
+              "lines": true,
+              "linewidth": 0,
+              "points": false,
+              "yaxis": 2
             }
           ],
           "span": 4,
@@ -540,6 +547,10 @@
             {
               "refId": "B",
               "target": "alias(service_is_carbon-relay-ng.instance_is_$instance.mtype_is_gauge.dest_is_$dest.unit_is_Metric.what_is_bufferSize, 'bufferSize')"
+            },
+            {
+              "refId": "C",
+              "target": "alias(service_is_carbon-relay-ng.instance_is_dev.mtype_is_gauge.what_is_virtual_memory.unit_is_Byte, 'memory-usage')"
             }
           ],
           "timeFrom": null,
@@ -563,7 +574,7 @@
               "show": true
             },
             {
-              "format": "short",
+              "format": "bytes",
               "max": null,
               "min": null,
               "show": true


### PR DESCRIPTION
fix #216

the main use here is to be able to tune buffer sizes based on actual ram usage, and to see when the relay restarts