### PR TITLE
an upstart that supports logging on cent6/amzn

### DIFF
--- a/examples/carbon-relay-ng.upstart-0.6.5
+++ b/examples/carbon-relay-ng.upstart-0.6.5
@@ -21,6 +21,13 @@ limit nofile 102400 102400
 #limit sigpending <softlimit> <hardlimit>
 #limit stack <softlimit> <hardlimit>
 
-
-exec chroot --userspec root:root / /usr/bin/carbon-relay-ng "/etc/carbon-relay-ng/carbon-relay-ng.conf"
-
+### NOTE: logging does not work on the older version of upstart without a redirect as explained here http://upstart.ubuntu.com/cookbook/#versions-of-upstart-older-than-1-4 
+script
+  # When loading default and sysconfig files, we use `set -a` to make
+  # all variables automatically into environment variables.
+  set -a
+  [ -r "/etc/default/carbon-relay-ng" ] && . "/etc/default/carbon-relay-ng"
+  [ -r "/etc/sysconfig/carbon-relay-ng" ] && . "/etc/sysconfig/carbon-relay-ng"
+  set +a
+  exec chroot --userspec root:root / /usr/bin/carbon-relay-ng  >> /var/log/carbon-relay-ng-stdout.log 2>> /var/log/carbon-relay-ng-stderr.log
+end script


### PR DESCRIPTION
This is an upstart fix as explained in https://github.com/graphite-ng/carbon-relay-ng/issues/223. Though i would prefer a sysv solution for these distributions. 




