### PR TITLE
Aggregator improves

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Note:
 * functions currently available: avg, delta, last, max, min, stdev, sum
 * aggregation output is routed via the routing table just like all other metrics.  Note that aggregation output will never go back into aggregators (to prevent loops) and also bypasses the validation and blacklist and rewriters.
 * see the included ini for examples
+* each aggregator can be configured to cache regex matches or not. there is no cache size limit because a limited size, under a typical workload where we see each metric key sequentially, in perpetual cycles, would just result in cache thrashing and wasting memory. If enabled, all matches are cached for at least 100 times the wait parameter. By default, the cache is enabled for aggregators set up via commands (init commands in the config) but disabled for aggregators configured via config sections (due to a limitation in our config library).  Basically enabling the cache means you trade in RAM for cpu.
 
 Rewriting
 ---------
@@ -217,7 +218,7 @@ commands:
     addRewriter <old> <new> <max>                add rewriter that will rewrite all old to new, max times
                                                  use /old/ to specify a regular expression match, with support for ${1} style identifiers in new
 
-    addAgg <func> <regex> <fmt> <interval> <wait>  add a new aggregation rule.
+    addAgg <func> <regex> <fmt> <interval> <wait> [cache=true/false] add a new aggregation rule.
              <func>:                             aggregation function to use
                avg
                delta

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -1,10 +1,10 @@
 package aggregator
 
 import (
-	"fmt"
+	"bytes"
 	"strconv"
-	"sync"
 	"testing"
+	"time"
 )
 
 func TestScanner(t *testing.T) {
@@ -80,66 +80,83 @@ func TestScanner(t *testing.T) {
 	}
 }
 
+// an operation here is an aggregation, comprising of 2*aggregates*pointsPerAggregate points,
+// (with just as many points ignored each time)
+func BenchmarkAggregator1Aggregates2PointsPerAggregate(b *testing.B) {
+	benchmarkAggregator(1, 2, "4.0000", b)
+}
+func BenchmarkAggregator5Aggregates10PointsPerAggregate(b *testing.B) {
+	benchmarkAggregator(5, 10, "20.000", b)
+}
+func BenchmarkAggregator5Aggregates100PointsPerAggregate(b *testing.B) {
+	benchmarkAggregator(5, 100, "200.00", b)
+}
+
 // we purposely keep the regex relatively simple because regex performance is up to the carbon-relay-ng user,
 // so we want to focus on the carbon-relay-ng features, not regex performance
 // b.N is how many points we generate (each based on 100 inputs)
-func BenchmarkAggregator(b *testing.B) {
-	reader := &sync.WaitGroup{}
-	out := make(chan []byte, 100)
-	reader.Add(1)
-	go func() {
+
+func benchmarkAggregator(aggregates, pointsPerAggregate int, match string, b *testing.B) {
+	//fmt.Println("BenchmarkAggregator", aggregates, pointsPerAggregate, "with b.N", b.N)
+	out := make(chan []byte)
+	done := make(chan struct{})
+	go func(match string) {
 		count := 0
 		for v := range out {
 			count += 1
-			//	if !ok {
-			//		b.Fatalf("out channel closed at count %d ??", count)
+			if bytes.HasPrefix(v, []byte("aggregated.totals.abc.ignoreme")) {
+				continue
+			}
+			if string(v[33:39]) != match {
+				b.Fatalf("expected 'aggregated.totals.abc.<10 random chars> %s... <ts>'. got: %q", match, v)
+			}
+			//	if count%100 == 0 {
+			//fmt.Println("got", string(v), "count is now", count)
 			//	}
-			//if v != 100 {
-			//		b.Fatalf("point %d: expected 100, got %f", count, v)
-			//	}
-			b.Logf("got %q", v)
-			if count == b.N {
-				reader.Done()
+			if count == aggregates*b.N {
+				close(done)
 				return
 			}
-
 		}
-	}()
+	}(match)
+
+	// at each timestamp we will send all the inputs we predeclare here, with as many matching as non-matching.
+	// (2*aggregates*pointsPerAggregate in total are sent at each timestamp)
+	// (2*aggregates*pointsPerAggregate matching points go into each aggregation, since each input is used twice see below)
 	var inputs [][]byte
-	for i := 0; i < 5; i++ {
+	for i := 0; i < aggregates; i++ {
 		key := "raw.abc." + RandString(10)
-		for j := 0; j < 10; j++ {
+		for j := 0; j < pointsPerAggregate; j++ {
 			inputs = append(inputs, []byte(key))
 		}
 	}
-	for i := 0; i < 50; i++ {
+	for i := 0; i < aggregates*pointsPerAggregate; i++ {
 		inputs = append(inputs, []byte("nomatch.foo.bar"))
 	}
-	var timestamps [][]byte
-	var wall []int64
+
 	// time starts at 1000. increase by 5
 	// we will do b.N aggregations (each 10s apart) and comprising 2 sets of points (5s apart)
 	// so there is 2*b.N input timestamps
-	// before adding the values, we set the clock to 22 after the ts of the points so it can flush prev point
+	// before adding the values, we set the clock to 12 after the ts of the points so it can flush prev point
+	// this means we can allow the aggregator to buffer only 2*aggregates*pointsPerAggregate points, otherwise buffering would be unsafe
+	// at the speed that our benchmark runs (as it could trigger flush before it takes in the points)
 	// e.g. :
 	// pointTS - outputTs - wall
-	// 1000    - 1000      1022
-	// 1005    - 1000      1027
-	// 1010    - 1010      1022 -> flush point with outputTs 1000
-	// 1015    - 1010      1037
-	// 1020    - 1020      1032 -> flush point with outputTs 1010
-	// 1025    - 1020      1047
-	// 1030    - 1030      1042 -> flush point with outputTs 1020
-	// 1035    - 1030      1057
-	// 1040    - 1040      1052 -> flush point with outputTs 1030
-	var t uint64
-	for t = 1000; t < uint64(1000+(10*b.N)); t += 5 {
+	// 1000    - 1000      1012
+	// 1005    - 1000      1017
+	// 1010    - 1010      1022 -> flush point with outputTs 990
+	// 1015    - 1010      1027
+	// 1020    - 1020      1032 -> flush point with outputTs 1000
+	// 1025    - 1020      1037
+	// 1030    - 1030      1042 -> flush point with outputTs 1010
+	// 1035    - 1030      1047
+	// 1040    - 1040      1052 -> flush point with outputTs 1020
+	var timestamps [][]byte
+	var wall []int64
+	for t := uint64(1000); t < uint64(1000+(10*b.N)); t += 5 {
 		timestamps = append(timestamps, strconv.AppendUint(nil, t, 10))
-		wall = append(wall, int64(t+22))
+		wall = append(wall, int64(t+12))
 	}
-	// one more so we can flush last data
-	wall = append(wall, int64(t+22))
-
 	val := strconv.AppendUint(nil, 1, 10)
 
 	regex := `^raw\.(...)\.([A-Za-z0-9_-]+)$`
@@ -148,18 +165,17 @@ func BenchmarkAggregator(b *testing.B) {
 	clock := NewMockClock(0)
 	tick := NewMockTick(10)
 	clock.AddTick(tick)
+	bufSize := 2 * aggregates * pointsPerAggregate
 
-	agg, err := NewMocked("sum", regex, outFmt, 10, 30, out, clock.Now, tick.C)
+	agg, err := NewMocked("sum", regex, outFmt, 10, 30, out, bufSize, clock.Now, tick.C)
 	if err != nil {
 		b.Fatalf("couldn't create aggregation: %q", err)
 	}
 
-	fmt.Println("prep done", len(inputs))
-
 	b.ResetTimer()
 	for i, ts := range timestamps {
+		//	fmt.Println("setting clock to", wall[i], "and sending", len(inputs)/2, "will go through. for ts", string(ts))
 		clock.Set(wall[i])
-		fmt.Println("sending all vals for ts", wall[i])
 		for _, input := range inputs {
 			buf := [][]byte{
 				input,
@@ -169,7 +185,34 @@ func BenchmarkAggregator(b *testing.B) {
 			agg.AddMaybe(buf)
 		}
 	}
-	// flush last point
-	clock.Set(wall[len(wall)-1])
-	reader.Wait()
+	// we must make sure to get the final aggregated point.
+	// first of all, fill up the aggregator input buffer with metrics that will match and will go into the queue
+	// but can't affect any results we care about.
+	// making sure that all values we care about are pushed out of the buffer and processed.
+	//fmt.Println("adding", bufSize, "more to push through buffer")
+	for i := 0; i < bufSize; i++ {
+		buf := [][]byte{
+			[]byte("raw.abc.ignoreme"),
+			val,
+			timestamps[0],
+		}
+		agg.AddMaybe(buf)
+	}
+	// then, we keep updating the clock, triggering ticks, with high enough timestamps to surely flush the last aggregates.
+	// this so that if the aggregator is busy and doesn't read ticks, we keep trying until it isn't and does.
+	lastFlushTs := wall[len(wall)-1] + 1000
+	almostFinished := time.Now()
+	for {
+		select {
+		case <-done:
+			return
+		default:
+			if time.Since(almostFinished) > 2*time.Second {
+				b.Fatalf("waited 2 seconds for all results to come in. giving up")
+			}
+			clock.Set(lastFlushTs)
+			lastFlushTs += 10
+			time.Sleep(10 * time.Microsecond)
+		}
+	}
 }

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -1,6 +1,9 @@
 package aggregator
 
 import (
+	"fmt"
+	"strconv"
+	"sync"
 	"testing"
 )
 
@@ -75,4 +78,98 @@ func TestScanner(t *testing.T) {
 		}
 
 	}
+}
+
+// we purposely keep the regex relatively simple because regex performance is up to the carbon-relay-ng user,
+// so we want to focus on the carbon-relay-ng features, not regex performance
+// b.N is how many points we generate (each based on 100 inputs)
+func BenchmarkAggregator(b *testing.B) {
+	reader := &sync.WaitGroup{}
+	out := make(chan []byte, 100)
+	reader.Add(1)
+	go func() {
+		count := 0
+		for v := range out {
+			count += 1
+			//	if !ok {
+			//		b.Fatalf("out channel closed at count %d ??", count)
+			//	}
+			//if v != 100 {
+			//		b.Fatalf("point %d: expected 100, got %f", count, v)
+			//	}
+			b.Logf("got %q", v)
+			if count == b.N {
+				reader.Done()
+				return
+			}
+
+		}
+	}()
+	var inputs [][]byte
+	for i := 0; i < 5; i++ {
+		key := "raw.abc." + RandString(10)
+		for j := 0; j < 10; j++ {
+			inputs = append(inputs, []byte(key))
+		}
+	}
+	for i := 0; i < 50; i++ {
+		inputs = append(inputs, []byte("nomatch.foo.bar"))
+	}
+	var timestamps [][]byte
+	var wall []int64
+	// time starts at 1000. increase by 5
+	// we will do b.N aggregations (each 10s apart) and comprising 2 sets of points (5s apart)
+	// so there is 2*b.N input timestamps
+	// before adding the values, we set the clock to 22 after the ts of the points so it can flush prev point
+	// e.g. :
+	// pointTS - outputTs - wall
+	// 1000    - 1000      1022
+	// 1005    - 1000      1027
+	// 1010    - 1010      1022 -> flush point with outputTs 1000
+	// 1015    - 1010      1037
+	// 1020    - 1020      1032 -> flush point with outputTs 1010
+	// 1025    - 1020      1047
+	// 1030    - 1030      1042 -> flush point with outputTs 1020
+	// 1035    - 1030      1057
+	// 1040    - 1040      1052 -> flush point with outputTs 1030
+	var t uint64
+	for t = 1000; t < uint64(1000+(10*b.N)); t += 5 {
+		timestamps = append(timestamps, strconv.AppendUint(nil, t, 10))
+		wall = append(wall, int64(t+22))
+	}
+	// one more so we can flush last data
+	wall = append(wall, int64(t+22))
+
+	val := strconv.AppendUint(nil, 1, 10)
+
+	regex := `^raw\.(...)\.([A-Za-z0-9_-]+)$`
+	outFmt := "aggregated.totals.$1.$2"
+
+	clock := NewMockClock(0)
+	tick := NewMockTick(10)
+	clock.AddTick(tick)
+
+	agg, err := NewMocked("sum", regex, outFmt, 10, 30, out, clock.Now, tick.C)
+	if err != nil {
+		b.Fatalf("couldn't create aggregation: %q", err)
+	}
+
+	fmt.Println("prep done", len(inputs))
+
+	b.ResetTimer()
+	for i, ts := range timestamps {
+		clock.Set(wall[i])
+		fmt.Println("sending all vals for ts", wall[i])
+		for _, input := range inputs {
+			buf := [][]byte{
+				input,
+				val,
+				ts,
+			}
+			agg.AddMaybe(buf)
+		}
+	}
+	// flush last point
+	clock.Set(wall[len(wall)-1])
+	reader.Wait()
 }

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -83,20 +83,30 @@ func TestScanner(t *testing.T) {
 // an operation here is an aggregation, comprising of 2*aggregates*pointsPerAggregate points,
 // (with just as many points ignored each time)
 func BenchmarkAggregator1Aggregates2PointsPerAggregate(b *testing.B) {
-	benchmarkAggregator(1, 2, "4.0000", b)
+	benchmarkAggregator(1, 2, "4.0000", false, b)
 }
 func BenchmarkAggregator5Aggregates10PointsPerAggregate(b *testing.B) {
-	benchmarkAggregator(5, 10, "20.000", b)
+	benchmarkAggregator(5, 10, "20.000", false, b)
 }
 func BenchmarkAggregator5Aggregates100PointsPerAggregate(b *testing.B) {
-	benchmarkAggregator(5, 100, "200.00", b)
+	benchmarkAggregator(5, 100, "200.00", false, b)
+}
+
+func BenchmarkAggregator1Aggregates2PointsPerAggregateWithReCache(b *testing.B) {
+	benchmarkAggregator(1, 2, "4.0000", true, b)
+}
+func BenchmarkAggregator5Aggregates10PointsPerAggregateWithReCache(b *testing.B) {
+	benchmarkAggregator(5, 10, "20.000", true, b)
+}
+func BenchmarkAggregator5Aggregates100PointsPerAggregateWithReCache(b *testing.B) {
+	benchmarkAggregator(5, 100, "200.00", true, b)
 }
 
 // we purposely keep the regex relatively simple because regex performance is up to the carbon-relay-ng user,
 // so we want to focus on the carbon-relay-ng features, not regex performance
 // b.N is how many points we generate (each based on 100 inputs)
 
-func benchmarkAggregator(aggregates, pointsPerAggregate int, match string, b *testing.B) {
+func benchmarkAggregator(aggregates, pointsPerAggregate int, match string, cache bool, b *testing.B) {
 	//fmt.Println("BenchmarkAggregator", aggregates, pointsPerAggregate, "with b.N", b.N)
 	out := make(chan []byte)
 	done := make(chan struct{})
@@ -176,7 +186,7 @@ func benchmarkAggregator(aggregates, pointsPerAggregate int, match string, b *te
 	clock.AddTick(tick)
 	bufSize := 2 * aggregates * pointsPerAggregate
 
-	agg, err := NewMocked("sum", regex, outFmt, 10, 30, out, bufSize, clock.Now, tick.C)
+	agg, err := NewMocked("sum", regex, outFmt, cache, 10, 30, out, bufSize, clock.Now, tick.C)
 	if err != nil {
 		b.Fatalf("couldn't create aggregation: %q", err)
 	}

--- a/aggregator/mock_clock_test.go
+++ b/aggregator/mock_clock_test.go
@@ -1,0 +1,73 @@
+package aggregator
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// mockTickr is a mock ticker,
+// which exactly on the interval
+// it needs to be told about time advancement
+type mockTick struct {
+	C        chan time.Time
+	last     int64
+	interval int64
+}
+
+func NewMockTick(interval int64) *mockTick {
+	return &mockTick{
+		C:        make(chan time.Time),
+		interval: interval,
+	}
+}
+
+func (m *mockTick) Set(t int64) {
+	// already ticked recently enough?
+	if (t - m.last) < m.interval {
+		return
+	}
+	// first time this ticker runs, let it tick once.
+	if m.last == 0 {
+		m.last = t - m.interval
+	}
+	// note that this will tick in very quick succession
+	// and if multiple, ticks are likely to be dropped
+	// for our unit tests this is ok as we'll only tick
+	// once each time.
+	for ; m.last <= t; m.last += m.interval {
+		select {
+		case m.C <- time.Unix(m.last, 0):
+		default:
+		}
+	}
+}
+
+// mockClock simple fake clock with some tickchans
+// (we can't provide actual time.Ticker's because they're not
+// an interface, and if we use a concrete one, we can't write
+// to their C channel.
+type mockClock struct {
+	now   int64
+	ticks []*mockTick
+}
+
+func NewMockClock(t int64) *mockClock {
+	m := &mockClock{}
+	atomic.StoreInt64(&m.now, t)
+	return m
+}
+
+func (m *mockClock) Set(t int64) {
+	atomic.StoreInt64(&m.now, t)
+	for _, tick := range m.ticks {
+		tick.Set(t)
+	}
+}
+
+func (m *mockClock) Now() time.Time {
+	return time.Unix(atomic.LoadInt64(&m.now), 0)
+}
+
+func (m *mockClock) AddTick(mt *mockTick) {
+	m.ticks = append(m.ticks, mt)
+}

--- a/aggregator/rand_test.go
+++ b/aggregator/rand_test.go
@@ -1,0 +1,30 @@
+package aggregator
+
+import "math/rand"
+
+// from https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-golang
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+const (
+	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+)
+
+func RandString(n int) string {
+	b := make([]byte, n)
+	// A rand.Int63() generates 63 random bits, enough for letterIdxMax letters!
+	for i, cache, remain := n-1, rand.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = rand.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return string(b)
+}

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -32,6 +32,7 @@ type Aggregation struct {
 	Function string
 	Regex    string
 	Format   string
+	Cache    bool
 	Interval int
 	Wait     int
 }

--- a/clock/clock.go
+++ b/clock/clock.go
@@ -1,0 +1,26 @@
+package clock
+
+import "time"
+
+// AlignedTick returns a tick channel so that, let's say interval is a second
+// then it will tick at every whole second, or if it's 60s than it's every whole
+// minute. Note that in my testing this is about .0001 to 0.0002 seconds later due
+// to scheduling etc.
+func AlignedTick(period time.Duration) <-chan time.Time {
+	// note that time.Ticker is not an interface,
+	// and that if we instantiate one, we can't write to its channel
+	// hence we can't leverage that type.
+	c := make(chan time.Time)
+	go func() {
+		for {
+			unix := time.Now().UnixNano()
+			diff := time.Duration(period - (time.Duration(unix) % period))
+			time.Sleep(diff)
+			select {
+			case c <- time.Now():
+			default:
+			}
+		}
+	}()
+	return c
+}

--- a/cmd/carbon-relay-ng/testEndpoint_test.go
+++ b/cmd/carbon-relay-ng/testEndpoint_test.go
@@ -239,12 +239,13 @@ func (data arr) Less(i, j int) bool {
 }
 
 // assume that ref feeds in sorted order, because we rely on that!
-func (tE *TestEndpoint) SeenThisOrFatal(ref chan []byte) {
+func (tE *TestEndpoint) SeenThisOrFatal(ref chan msg) {
 	tE.WhatHaveISeen <- true
 	seen := <-tE.IHaveSeen
 	sort.Sort(arr(seen))
 	getRefBuf := func() []byte {
-		return <-ref
+		msg := <-ref
+		return msg.Buf
 	}
 	i := 0
 	getSeenBuf := func() []byte {

--- a/input/amqp.go
+++ b/input/amqp.go
@@ -134,7 +134,7 @@ func (a *Amqp) dispatch(buf []byte) {
 	numIn.Inc(1)
 	log.Debug("dispatching message: %s", buf)
 
-	key, _, ts, err := m20.ValidatePacket(buf, a.config.Validation_level_legacy.Level, a.config.Validation_level_m20.Level)
+	key, val, ts, err := m20.ValidatePacket(buf, a.config.Validation_level_legacy.Level, a.config.Validation_level_m20.Level)
 	if err != nil {
 		a.bad.Add(key, buf, err)
 		numInvalid.Inc(1)
@@ -150,5 +150,5 @@ func (a *Amqp) dispatch(buf []byte) {
 		}
 	}
 
-	a.table.Dispatch(buf)
+	a.table.Dispatch(buf, val, ts)
 }

--- a/input/pickle.go
+++ b/input/pickle.go
@@ -168,7 +168,7 @@ ReadLoop:
 			buf := []byte(metric + " " + value + " " + timestamp)
 
 			log.Debug("pickle.go: passing unpickled metric to m20 Packet validator...")
-			key, _, ts, err := m20.ValidatePacket(buf, p.config.Validation_level_legacy.Level, p.config.Validation_level_m20.Level)
+			key, val, ts, err := m20.ValidatePacket(buf, p.config.Validation_level_legacy.Level, p.config.Validation_level_m20.Level)
 			if err != nil {
 				log.Debug("pickle.go: metric failed to pass m20 Packet validation!")
 				p.bad.Add(key, buf, err)
@@ -188,7 +188,7 @@ ReadLoop:
 			}
 
 			log.Debug("pickle.go: all good, dispatching metrics buffer")
-			p.table.Dispatch(buf)
+			p.table.Dispatch(buf, val, ts)
 
 			log.Debug("pickle.go: exiting ItemLoop")
 		}

--- a/input/plain.go
+++ b/input/plain.go
@@ -51,7 +51,7 @@ func (p *Plain) Handle(c net.Conn) {
 
 		numIn.Inc(1)
 
-		key, _, ts, err := m20.ValidatePacket(buf, p.config.Validation_level_legacy.Level, p.config.Validation_level_m20.Level)
+		key, val, ts, err := m20.ValidatePacket(buf, p.config.Validation_level_legacy.Level, p.config.Validation_level_m20.Level)
 		if err != nil {
 			p.bad.Add(key, buf, err)
 			numInvalid.Inc(1)
@@ -67,6 +67,6 @@ func (p *Plain) Handle(c net.Conn) {
 			}
 		}
 
-		p.table.Dispatch(buf)
+		p.table.Dispatch(buf, val, ts)
 	}
 }

--- a/table/table.go
+++ b/table/table.go
@@ -405,8 +405,8 @@ func (table *Table) Print() (str string) {
 	rowFmtRW := fmt.Sprintf("%%%ds %%%ds %%%dd\n", maxRWOld+1, maxRWNew+1, maxRWMax+1)
 	heaFmtB := fmt.Sprintf("%%%ds %%%ds %%%ds\n", maxBPrefix+1, maxBSub+1, maxBRegex+1)
 	rowFmtB := fmt.Sprintf("%%%ds %%%ds %%%ds\n", maxBPrefix+1, maxBSub+1, maxBRegex+1)
-	heaFmtA := fmt.Sprintf("%%%ds %%%ds %%%ds %%%ds %%%ds\n", maxAFunc+1, maxARegex+1, maxAOutFmt+1, maxAInterval+1, maxAwait+1)
-	rowFmtA := fmt.Sprintf("%%%ds %%%ds %%%ds %%%dd %%%dd\n", maxAFunc+1, maxARegex+1, maxAOutFmt+1, maxAInterval+1, maxAwait+1)
+	heaFmtA := fmt.Sprintf("%%%ds %%%ds %%%ds %%6s %%%ds %%%ds\n", maxAFunc+1, maxARegex+1, maxAOutFmt+1, maxAInterval+1, maxAwait+1)
+	rowFmtA := fmt.Sprintf("%%%ds %%%ds %%%ds %%6t %%%dd %%%dd\n", maxAFunc+1, maxARegex+1, maxAOutFmt+1, maxAInterval+1, maxAwait+1)
 	heaFmtR := fmt.Sprintf("  %%%ds %%%ds %%%ds %%%ds %%%ds\n", maxRType+1, maxRKey+1, maxRPrefix+1, maxRSub+1, maxRRegex+1)
 	rowFmtR := fmt.Sprintf("> %%%ds %%%ds %%%ds %%%ds %%%ds\n", maxRType+1, maxRKey+1, maxRPrefix+1, maxRSub+1, maxRRegex+1)
 	heaFmtD := fmt.Sprintf("        %%%ds %%%ds %%%ds %%%ds %%%ds %%6s %%6s %%6s\n", maxDPrefix+1, maxDSub+1, maxDRegex+1, maxDAddr+1, maxDSpoolDir+1)
@@ -436,10 +436,10 @@ func (table *Table) Print() (str string) {
 	}
 
 	str += "\n## Aggregations:\n"
-	cols = fmt.Sprintf(heaFmtA, "func", "regex", "outFmt", "interval", "wait")
+	cols = fmt.Sprintf(heaFmtA, "func", "regex", "outFmt", "cache", "interval", "wait")
 	str += cols + underscore(len(cols))
 	for _, agg := range t.Aggregators {
-		str += fmt.Sprintf(rowFmtA, agg.Fun, agg.Regex, agg.OutFmt, agg.Interval, agg.Wait)
+		str += fmt.Sprintf(rowFmtA, agg.Fun, agg.Regex, agg.OutFmt, agg.Cache, agg.Interval, agg.Wait)
 	}
 
 	str += "\n## Routes:\n"
@@ -544,7 +544,7 @@ func (table *Table) InitBlacklist(config cfg.Config) error {
 
 func (table *Table) InitAggregation(config cfg.Config) error {
 	for i, aggConfig := range config.Aggregation {
-		agg, err := aggregator.New(aggConfig.Function, aggConfig.Regex, aggConfig.Format, uint(aggConfig.Interval), uint(aggConfig.Wait), table.In)
+		agg, err := aggregator.New(aggConfig.Function, aggConfig.Regex, aggConfig.Format, aggConfig.Cache, uint(aggConfig.Interval), uint(aggConfig.Wait), table.In)
 		if err != nil {
 			log.Error(err.Error())
 			return fmt.Errorf("could not add aggregation #%d", i+1)

--- a/table/table.go
+++ b/table/table.go
@@ -100,9 +100,7 @@ func (table *Table) Dispatch(buf []byte) {
 
 	for _, aggregator := range conf.aggregators {
 		// we rely on incoming metrics already having been validated
-		if aggregator.PreMatch(fields[0]) {
-			aggregator.In <- fields
-		}
+		aggregator.AddMaybe(fields)
 	}
 
 	final := bytes.Join(fields, []byte(" "))

--- a/table/table.go
+++ b/table/table.go
@@ -78,7 +78,7 @@ func (table *Table) GetSpoolDir() string {
 // it dispatches incoming metrics into matching aggregators and routes,
 // after checking against the blacklist
 // buf is assumed to have no whitespace at the end
-func (table *Table) Dispatch(buf []byte) {
+func (table *Table) Dispatch(buf []byte, val float64, ts uint32) {
 	buf_copy := make([]byte, len(buf))
 	copy(buf_copy, buf)
 	log.Debug("table received packet %s", buf_copy)
@@ -100,7 +100,7 @@ func (table *Table) Dispatch(buf []byte) {
 
 	for _, aggregator := range conf.aggregators {
 		// we rely on incoming metrics already having been validated
-		aggregator.AddMaybe(fields)
+		aggregator.AddMaybe(fields, val, ts)
 	}
 
 	final := bytes.Join(fields, []byte(" "))

--- a/ui/telnet/telnet.go
+++ b/ui/telnet/telnet.go
@@ -57,7 +57,7 @@ commands:
     addRewriter <old> <new> <max>                add rewriter that will rewrite all old to new, max times
                                                  use /old/ to specify a regular expression match, with support for ${1} style identifiers in new
 
-    addAgg <func> <regex> <fmt> <interval> <wait>  add a new aggregation rule.
+    addAgg <func> <regex> <fmt> <interval> <wait> [cache=true/false] add a new aggregation rule.
              <func>:                             aggregation function to use
                avg
                delta

--- a/ui/web/admin_http_assets/index.html
+++ b/ui/web/admin_http_assets/index.html
@@ -140,6 +140,7 @@
                   <th>Function</th>
                   <th>Regex</th>
                   <th>Output format</th>
+                  <th>Cache</th>
                   <th>Interval (sec)</th>
                   <th>Wait (sec)</th>
                   <th>Actions</th>
@@ -150,6 +151,7 @@
                     <td>{{a.fun}}</td>
                     <td>{{a.regex}}</td>
                     <td>{{a.OutFmt}}</td>
+                    <td>{{a.Cache}}</td>
                     <td>{{a.Interval}}</td>
                     <td>{{a.Wait}}</td>
                     <td class="text-center"><a ng-click="removeAggregator($index)"><i class="glyphicon glyphicon-remove-circle"/></a></td>
@@ -172,6 +174,9 @@
                     </td>
                     <td class="form-group has-feedback">
                         <input ng-model="newAgg.OutFmt" name="outfmt" class="form-control" placeholder="out" required>
+                    </td>
+                    <td class="form-group has-feedback">
+                      <input type="checkbox" ng-model="newAgg.Cache" name="Cache" class="form-control">
                     </td>
                     <td class="form-group has-feedback">
                         <input type="number" ng-model="newAgg.Interval" name="interval" class="form-control" ng-pattern="/^[0-9]+$/">

--- a/ui/web/web.go
+++ b/ui/web/web.go
@@ -220,6 +220,7 @@ func parseAggregateRequest(r *http.Request) (*aggregator.Aggregator, *handlerErr
 	var request struct {
 		Fun      string
 		OutFmt   string
+		Cache    bool
 		Interval uint
 		Wait     uint
 		Regex    string
@@ -227,7 +228,7 @@ func parseAggregateRequest(r *http.Request) (*aggregator.Aggregator, *handlerErr
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return nil, &handlerError{err, "Couldn't parse json", http.StatusBadRequest}
 	}
-	aggregate, err := aggregator.New(request.Fun, request.Regex, request.OutFmt, request.Interval, request.Wait, table.In)
+	aggregate, err := aggregator.New(request.Fun, request.Regex, request.OutFmt, request.Cache, request.Interval, request.Wait, table.In)
 	if err != nil {
 		return nil, &handlerError{err, "Couldn't create aggregator", http.StatusBadRequest}
 	}


### PR DESCRIPTION
significant performance improvements:
```
benchcmp v1.txt clean-cache.txt
benchmark                                                 old ns/op     new ns/op     delta
BenchmarkAggregator1Aggregates2PointsPerAggregate-8       11284         10015         -11.25%
BenchmarkAggregator5Aggregates10PointsPerAggregate-8      8561049       135632        -98.42%
BenchmarkAggregator5Aggregates100PointsPerAggregate-8     15326290      1187623       -92.25%
```

when enabling the regex cache, duration is cut in half yet again (in exchange for more RAM usage)
```
cat clean-cache.txt
goos: linux
goarch: amd64
pkg: github.com/graphite-ng/carbon-relay-ng/aggregator
BenchmarkAggregator1Aggregates2PointsPerAggregate-8                	  200000	     10015 ns/op
BenchmarkAggregator5Aggregates10PointsPerAggregate-8               	   10000	    135632 ns/op
BenchmarkAggregator5Aggregates100PointsPerAggregate-8              	    1000	   1187623 ns/op
BenchmarkAggregator1Aggregates2PointsPerAggregateWithReCache-8     	  300000	      5761 ns/op
BenchmarkAggregator5Aggregates10PointsPerAggregateWithReCache-8    	   20000	     78453 ns/op
BenchmarkAggregator5Aggregates100PointsPerAggregateWithReCache-8   	    3000	    496872 ns/op
PASS
ok  	github.com/graphite-ng/carbon-relay-ng/aggregator	10.906s
```