### PR TITLE
Use useradd to support multiple distros

### DIFF
--- a/examples/after_install.sh
+++ b/examples/after_install.sh
@@ -3,7 +3,7 @@
 
 setup_carbon_relay_user() {
     if ! getent passwd carbon-relay-ng >/dev/null; then
-        adduser --quiet --system --group --no-create-home --home /var/run/carbon-relay-ng --shell /usr/sbin/nologin carbon-relay-ng
+        useradd --system --user-group --no-create-home --home /var/run/carbon-relay-ng --shell /usr/sbin/nologin carbon-relay-ng
     fi
 }
 


### PR DESCRIPTION
See https://github.com/graphite-ng/carbon-relay-ng/issues/232

I would make a pull request but I don't have RedHat installation ready to test. Anyone who can output me useradd --help and adduser --help from RedHat?

I checked these man pages for this change:
* https://linux.die.net/man/8/adduser
* https://linux.die.net/man/8/useradd
