### PR TITLE
default grafanaNet to 10s

### DIFF
--- a/docs/routes.md
+++ b/docs/routes.md
@@ -49,7 +49,7 @@ concurrency    |     N     |  int        | 10      | number of concurrent connec
 bufSize        |     N     |  int        | 10M     | buffer size. assume +- 100B per message, so 10M is about 1GB of RAM
 flushMaxNum    |     N     |  int        | 10k     | max number of metrics to buffer before triggering flush
 flushMaxWait   |     N     |  int (ms)   | 500     | max time to buffer before triggering flush
-timeout        |     N     |  int (ms)   | 5000    | abort and retry requests to api gateway if takes longer than this.
+timeout        |     N     |  int (ms)   | 10000   | abort and retry requests to api gateway if takes longer than this.
 orgId          |     N     |  int        | 1       |
 
 ## kafkaMdm route

--- a/imperatives/imperatives.go
+++ b/imperatives/imperatives.go
@@ -406,7 +406,7 @@ func readAddRouteGrafanaNet(s *toki.Scanner, table Table) error {
 	var bufSize = int(1e7)  // since a message is typically around 100B this is 1GB
 	var flushMaxNum = 10000 // number of metrics
 	var flushMaxWait = 500  // in ms
-	var timeout = 5000      // in ms
+	var timeout = 10000     // in ms
 	var concurrency = 10    // number of concurrent connections to tsdb-gw
 	var orgId = 1
 

--- a/table/table.go
+++ b/table/table.go
@@ -630,7 +630,7 @@ func (table *Table) InitRoutes(config cfg.Config) error {
 			var bufSize = int(1e7)  // since a message is typically around 100B this is 1GB
 			var flushMaxNum = 10000 // number of metrics
 			var flushMaxWait = 500  // in ms
-			var timeout = 5000      // in ms
+			var timeout = 10000     // in ms
 			var concurrency = 10    // number of concurrent connections to tsdb-gw
 			var orgId = 1
 


### PR DESCRIPTION
for most of our customers this makes more sense
too-short timeouts are expensive because if you hit them, the entire request has to be retried. this can quickly cascade into exhausting bandwidth/piling up the queue

@DanCech @woodsaj 