### PR TITLE
fix goroutine and memory leak in keepSafe

### DIFF
--- a/destination/conn.go
+++ b/destination/conn.go
@@ -282,6 +282,8 @@ func (c *Conn) Close() error {
 	c.updateUp <- false // redundant in case HandleData() called us, but not if the dest called us
 	log.Debugf("conn %s Close() called. sending shutdown", c.dest.Key)
 	c.shutdown <- true
+	log.Debugf("conn %s c.keepSafe.Close()\n", c.dest.Key)
+	c.keepSafe.Stop()
 	log.Debugf("conn %s c.conn.Close()", c.dest.Key)
 	a := c.conn.Close()
 	log.Debugf("conn %s c.conn is closed", c.dest.Key)

--- a/destination/keepsafe.go
+++ b/destination/keepsafe.go
@@ -5,32 +5,46 @@ import (
 	"time"
 )
 
+// keepSafe is a buffer which retains
+// at least the last periodKeep's worth of data
+// typically you get between periodKeep and 2*periodKeep
+// but don't rely on that
 type keepSafe struct {
 	initialCap int
 	safeOld    [][]byte
 	safeRecent [][]byte
-	periodKeep time.Duration // period to keep at least.  you get this period + a bit more
+	periodKeep time.Duration
+	closed     chan struct{}
+	wg         sync.WaitGroup
 	sync.Mutex
 }
 
 func NewKeepSafe(initialCap int, periodKeep time.Duration) *keepSafe {
-	k := keepSafe{
+	k := &keepSafe{
 		initialCap: initialCap,
 		safeOld:    make([][]byte, 0, initialCap),
 		safeRecent: make([][]byte, 0, initialCap),
 		periodKeep: periodKeep,
+		closed:     make(chan struct{}),
 	}
+	k.wg.Add(1)
 	go k.keepClean()
-	return &k
+	return k
 }
 
 func (k *keepSafe) keepClean() {
 	tick := time.NewTicker(k.periodKeep)
-	for range tick.C {
-		k.Lock()
-		k.safeOld = k.safeRecent
-		k.safeRecent = make([][]byte, 0, k.initialCap)
-		k.Unlock()
+	defer k.wg.Done()
+	for {
+		select {
+		case <-k.closed:
+			return
+		case <-tick.C:
+			k.Lock()
+			k.safeOld = k.safeRecent
+			k.safeRecent = make([][]byte, 0, k.initialCap)
+			k.Unlock()
+		}
 	}
 }
 
@@ -47,4 +61,11 @@ func (k *keepSafe) GetAll() [][]byte {
 	k.safeRecent = make([][]byte, 0, k.initialCap)
 	k.Unlock()
 	return ret
+}
+
+func (k *keepSafe) Stop() {
+	k.Lock()
+	close(k.closed)
+	k.wg.Wait()
+	k.Unlock()
 }


### PR DESCRIPTION
1) proper shutdown, fixing the keepClean goroutine leak
2) because of 1, allow the keepSafe object to be properly cleaned up
   instead of sticking around forever