### PR TITLE
refactor concurrent sending

### DIFF
--- a/route/grafananet.go
+++ b/route/grafananet.go
@@ -213,7 +213,11 @@ func (route *GrafanaNet) retryFlush(metrics []*schema.MetricData, buffer *bytes.
 		Jitter: true,
 	}
 	var dur time.Duration
-	for dur, err = route.flush(req); err != nil; {
+	for {
+		dur, err = route.flush(req)
+		if err == nil {
+			break
+		}
 		route.numErrFlush.Inc(1)
 		b := boff.Duration()
 		log.Warning("GrafanaNet failed to submit data: %s - will try again in %s (this attempt took %s)", err.Error(), b, dur)


### PR DESCRIPTION
with previous implementation, if any shard was busy flushing,
due to its unbuffered channel, any subsequest flush call on that
shard would block route.run(), preventing it from triggering flush
on any other shards.
We solve it by making every shard individually buffered, and
simplifying the code in the process.