### PR TITLE
Make StorageResolution for CloudWatch routes configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Like carbon-relay from the graphite project, except it:
  * performs better: should be able to do about 100k ~ 1M million metrics per second depending on configuration and CPU speed.
  * you can adjust the routing table at runtime, in real time using the web or telnet interface (though they may have some rough edges)
  * has aggregator functionality built-in for cross-series, cross-time and cross-time-and-series aggregations.
- * supports plaintext and pickle graphite routes (output) and metrics2.0/grafana.net, as well as kafka and Google PubSub.
+ * supports plaintext and pickle graphite routes (output) and metrics2.0/grafana.net, as well as kafka, Google PubSub and Amazon CloudWatch.
  * graphite routes supports a per-route spooling policy.
    (i.e. in case of an endpoint outage, we can temporarily queue the data up to disk and resume later)
  * performs validation on all incoming metrics (see below)

--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -76,10 +76,11 @@ type Route struct {
 	FlushMaxSize int
 
 	// CloudWatch
-	Profile    string // For local development
-	Region     string
-	Namespace  string     // For now fixed in config
-	Dimensions [][]string // For now fixed in config
+	Profile           string // For local development
+	Region            string
+	Namespace         string     // For now fixed in config
+	Dimensions        [][]string // For now fixed in config
+	StorageResolution int64
 }
 
 type Rewriter struct {

--- a/examples/carbon-relay-ng.ini
+++ b/examples/carbon-relay-ng.ini
@@ -177,6 +177,11 @@ destinations = [
 #dimensions = [
 #   ['myDimension', 'myDimensionVal'],
 #]
+# Valid values are 1 and 60. Setting this to 1 specifies this metric as a high-resolution
+# metric, so that CloudWatch stores the metric with sub-minute resolution down
+# to one second. Setting this to 60 specifies this metric as a regular-resolution
+# metric, which CloudWatch stores at 1-minute resolution.
+#storageResolution = 1
 
 [init]
 # you can also put init commands here, in the same format as you'd use for the telnet interface

--- a/table/table.go
+++ b/table/table.go
@@ -730,9 +730,10 @@ func (table *Table) InitRoutes(config cfg.Config) error {
 			}
 			table.AddRoute(route)
 		case "cloudWatch":
-			var bufSize = int(1e7)     // since a message is typically around 100B this is 1GB
-			var flushMaxSize = int(20) // Amazon limits to 20 MetricDatum/PutMetricData request https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html
-			var flushMaxWait = 10000   // in ms
+			var bufSize = int(1e7)            // since a message is typically around 100B this is 1GB
+			var flushMaxSize = int(20)        // Amazon limits to 20 MetricDatum/PutMetricData request https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_limits.html
+			var flushMaxWait = 10000          // in ms
+			var storageResolution = int64(60) // Default CloudWatch resolution is 60s
 			var awsProfile = ""
 			var awsRegion = ""
 			var awsNamespace = ""
@@ -759,8 +760,11 @@ func (table *Table) InitRoutes(config cfg.Config) error {
 			if len(routeConfig.Dimensions) > 0 {
 				awsDimensions = routeConfig.Dimensions
 			}
+			if routeConfig.StorageResolution != 0 {
+				storageResolution = routeConfig.StorageResolution
+			}
 
-			route, err := route.NewCloudWatch(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, awsProfile, awsRegion, awsNamespace, awsDimensions, bufSize, flushMaxSize, flushMaxWait, routeConfig.Blocking)
+			route, err := route.NewCloudWatch(routeConfig.Key, routeConfig.Prefix, routeConfig.Substr, routeConfig.Regex, awsProfile, awsRegion, awsNamespace, awsDimensions, bufSize, flushMaxSize, flushMaxWait, storageResolution, routeConfig.Blocking)
 			if err != nil {
 				log.Error(err.Error())
 				return fmt.Errorf("error adding route '%s'", routeConfig.Key)


### PR DESCRIPTION
* StorageResolution = 1 specifies this metric as a high-resolution metric, so that CloudWatch stores the metric with sub-minute resolution down to one second.
* StorageResolution = 60 specifies this metric as a regular-resolution metric, which CloudWatch stores at 1-minute resolution.
* See http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics