### PR TITLE
INFRA-6061 - change in Makefile to include init script in RPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ rpm-centos6: build
 	install man/man1/carbon-relay-ng.1 redhat/usr/share/man/man1
 	install examples/carbon-relay-ng.ini redhat/etc/carbon-relay-ng/carbon-relay-ng.conf
 	install examples/carbon-relay-ng.upstart-0.6.5 redhat/etc/init/carbon-relay-ng.conf
+	install examples/carbon-relay-ng.init redhat/etc/init.d/carbon-relay-ng
 	gzip redhat/usr/share/man/man1/carbon-relay-ng.1
 	fpm \
 		-s dir \


### PR DESCRIPTION
We're running on aws linux which uses rc style init scripts and would like that init script to be provided by the rpm.