### PR TITLE
Improve handling of invalid pickle input

### DIFF
--- a/input/pickle.go
+++ b/input/pickle.go
@@ -34,7 +34,7 @@ func NewPickle(config cfg.Config, addr string, tbl *table.Table, bad *badmetrics
 func (p *Pickle) Handle(c net.Conn) {
 	defer c.Close()
 	// TODO c.SetTimeout(60e9)
-	r := bufio.NewReaderSize(c, 4096)
+	r := bufio.NewReader(c)
 	log.Debug("pickle.go: entering ReadLoop...")
 ReadLoop:
 	for {
@@ -77,7 +77,7 @@ ReadLoop:
 			}
 		}
 
-		decoder := ogorek.NewDecoder(bytes.NewBuffer(payload))
+		decoder := ogorek.NewDecoder(bytes.NewReader(payload))
 
 		log.Debug("pickle.go: decoding pickled data...")
 		rawDecoded, err := decoder.Decode()


### PR DESCRIPTION
There are a few things that can go wrong with the pickle input handler, the worst of which is that if a sender is configured to send line protocol data to the pickle port then the code that reads the first 4 bytes of the input as a little-endian 32bit integer that should represent the expected payload length is almost certainly going to receive 4 ASCII characters and come up with a number somewhere over 500MB.  It will then attempt to allocate a buffer to hold that payload, leading to memory usage issues.

This patch makes a few changes to the way that the pickle input is handled:

1) It sets a hard limit on the payload size of 500MB, this means that data streams starting with 4 (or more) ASCII characters will be rejected immediately due to them decoding to a very large 32bit integer.

2) It peeks at the first 3 bytes of the pickle payload, and verifies that they are the `opProto` byte (`0x80`), followed by the protocol version as an 8-bit int, followed by the `opEmptyList` byte (`]`) which are required for all valid payloads.  It doesn't verify the version as 2, but right now the pickle library we use does only support version 2.

3) Rather than allocating the entire buffer as a byte array up front, it uses a `bytes.Buffer` and reads the payload in 4KB chunks, adding them into the buffer as it goes and letting go handle the allocation.  The chunk size could potentially be increased to reduce the number of times that the payload buffer needs to be grown for average-sized inputs.