### PR TITLE
Fix sslVerify default=true for grafanaNet route using new syntax

### DIFF
--- a/cmd/carbon-relay-ng/carbon-relay-ng.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng.go
@@ -90,7 +90,8 @@ func main() {
 		config_file = val
 	}
 
-	if _, err := toml.DecodeFile(config_file, &config); err != nil {
+	meta, err := toml.DecodeFile(config_file, &config)
+	if err != nil {
 		log.Error("Cannot use config file '%s':\n", config_file)
 		log.Error(err.Error())
 		usage()
@@ -180,7 +181,7 @@ func main() {
 
 	log.Notice("initializing routing table...")
 
-	table, err := tbl.InitFromConfig(config)
+	table, err := tbl.InitFromConfig(config, meta)
 	if err != nil {
 		log.Error(err.Error())
 		os.Exit(1)

--- a/vendor/github.com/BurntSushi/toml/decode_meta.go
+++ b/vendor/github.com/BurntSushi/toml/decode_meta.go
@@ -6,7 +6,7 @@ import "strings"
 // be inferrable via reflection. In particular, whether a key has been defined
 // and the TOML type of a key.
 type MetaData struct {
-	mapping map[string]interface{}
+	Mapping map[string]interface{}
 	types   map[string]tomlType
 	keys    []Key
 	decoded map[string]bool
@@ -27,7 +27,7 @@ func (md *MetaData) IsDefined(key ...string) bool {
 
 	var hash map[string]interface{}
 	var ok bool
-	var hashOrVal interface{} = md.mapping
+	var hashOrVal interface{} = md.Mapping
 	for _, k := range key {
 		if hash, ok = hashOrVal.(map[string]interface{}); !ok {
 			return false


### PR DESCRIPTION
Master:  

| config      | sslVerify property |
| ----------- | ------------------ |
| unspecified | false              |
| true        | true               |
| false       | false              |


When the value is not specified it should default to true.
Our code doesn't know the difference between unspecified and explicitly specified to false,
so it assumes the latter, and when unspecified, changes the value from the default (true) back to false.

With patch applied:

| config      | sslVerify property |
| ----------- | ------------------ |
| unspecified | true              |
| true        | true               |
| false       | false              |

Notes:
* this affects all boolean config options that default to true. but sslVerify is the only case of this.
* the deprecated old syntax does not have this problem
* SslVerify, SSlVerIfy, SSLVERIFY all work to set the value explicitly (with new syntax)
* This issue came up briefly at https://github.com/BurntSushi/toml/issues/47
  It's unfortunate to have to patch the toml dependency code, I tried doing it more cleaner using
  something like `meta.IsDefined("route", "sslverify")` but couldn't get that to work
  as we have a slice of routes, and the IsDefined doesn't seem to support iterating over a slice and finding
  a specific route.
