### PR TITLE
[Discuss] simplify listeners

### DIFF
--- a/cmd/carbon-relay-ng/carbon-relay-ng.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng.go
@@ -147,7 +147,6 @@ func main() {
 		f.Close()
 	}
 
-	input.InitMetrics()
 	aggregator.InitMetrics()
 
 	go func() {
@@ -171,14 +170,6 @@ func main() {
 		go metrics.Graphite(metrics.DefaultRegistry, time.Duration(config.Instrumentation.Graphite_interval)*time.Millisecond, "", addr)
 	}
 
-	maxAge, err := time.ParseDuration(config.Bad_metrics_max_age)
-	if err != nil {
-		log.Error("could not parse badMetrics max age")
-		log.Error(err.Error())
-		os.Exit(1)
-	}
-	badMetrics = badmetrics.New(maxAge)
-
 	log.Notice("initializing routing table...")
 
 	table, err := tbl.InitFromConfig(config, meta)
@@ -196,7 +187,7 @@ func main() {
 	}
 
 	if config.Listen_addr != "" {
-		err = input.NewPlain(config, config.Listen_addr, table, badMetrics)
+		err = input.NewPlain(config.Listen_addr, table)
 		if err != nil {
 			log.Error(err.Error())
 			os.Exit(1)
@@ -204,7 +195,7 @@ func main() {
 	}
 
 	if config.Pickle_addr != "" {
-		err = input.NewPickle(config, config.Pickle_addr, table, badMetrics)
+		err = input.NewPickle(config.Pickle_addr, table)
 		if err != nil {
 			log.Error(err.Error())
 			os.Exit(1)
@@ -212,7 +203,7 @@ func main() {
 	}
 
 	if config.Amqp.Amqp_enabled == true {
-		go input.StartAMQP(config, table, badMetrics)
+		go input.StartAMQP(config, table)
 	}
 
 	if config.Admin_addr != "" {
@@ -226,7 +217,7 @@ func main() {
 	}
 
 	if config.Http_addr != "" {
-		go web.Start(config.Http_addr, config, table, badMetrics)
+		go web.Start(config.Http_addr, config, table)
 	}
 
 	select {}

--- a/cmd/carbon-relay-ng/dummyPackets_test.go
+++ b/cmd/carbon-relay-ng/dummyPackets_test.go
@@ -37,12 +37,12 @@ func NewDummyPackets(key string, amount int) *dummyPackets {
 	return &dummyPackets{key, amount, packetLen, scratch}
 }
 
-func (dp *dummyPackets) Get(i int) ([]byte, float64, uint32) {
+func (dp *dummyPackets) Get(i int) []byte {
 	if i >= dp.amount {
 		panic("can't ask for higher index then what we have in dummyPackets")
 	}
 	sliceFull := dp.scratch.Bytes()
-	return sliceFull[dp.packetLen*i : dp.packetLen*(i+1)], 123, uint32(tsBase + i + 1)
+	return sliceFull[dp.packetLen*i : dp.packetLen*(i+1)]
 }
 
 type msg struct {

--- a/input/init.go
+++ b/input/init.go
@@ -3,23 +3,12 @@ package input
 import (
 	"io"
 
-	metrics "github.com/Dieterbe/go-metrics"
-	"github.com/graphite-ng/carbon-relay-ng/stats"
 	logging "github.com/op/go-logging"
 )
 
 var (
-	log           = logging.MustGetLogger("input") // for tests. overridden by main
-	numIn         metrics.Counter
-	numInvalid    metrics.Counter
-	numOutOfOrder metrics.Counter
+	log = logging.MustGetLogger("input") // for tests. overridden by main
 )
-
-func InitMetrics() {
-	numIn = stats.Counter("unit=Metric.direction=in")
-	numInvalid = stats.Counter("unit=Err.type=invalid")
-	numOutOfOrder = stats.Counter("unit=Err.type=out_of_order")
-}
 
 func SetLogger(l *logging.Logger) {
 	log = l
@@ -27,4 +16,9 @@ func SetLogger(l *logging.Logger) {
 
 type Handler interface {
 	Handle(io.Reader)
+}
+
+type Dispatcher interface {
+	Dispatch(buf []byte)
+	IncNumInvalid()
 }

--- a/input/plain.go
+++ b/input/plain.go
@@ -3,22 +3,14 @@ package input
 import (
 	"bufio"
 	"io"
-
-	"github.com/graphite-ng/carbon-relay-ng/badmetrics"
-	"github.com/graphite-ng/carbon-relay-ng/cfg"
-	"github.com/graphite-ng/carbon-relay-ng/table"
-	"github.com/graphite-ng/carbon-relay-ng/validate"
-	m20 "github.com/metrics20/go-metrics20/carbon20"
 )
 
 type Plain struct {
-	config cfg.Config
-	bad    *badmetrics.BadMetrics
-	table  *table.Table
+	dispatcher Dispatcher
 }
 
-func NewPlain(config cfg.Config, addr string, tbl *table.Table, badMetrics *badmetrics.BadMetrics) error {
-	return listen(addr, &Plain{config, badMetrics, tbl})
+func NewPlain(addr string, dispatcher Dispatcher) error {
+	return listen(addr, &Plain{dispatcher})
 }
 
 func (p *Plain) Handle(c io.Reader) {
@@ -26,33 +18,13 @@ func (p *Plain) Handle(c io.Reader) {
 	for scanner.Scan() {
 		// Note that everything in this loop should proceed as fast as it can
 		// so we're not blocked and can keep processing
-		// so the validation, the pipeline initiated via table.Dispatch(), etc
+		// so the validation, the pipeline initiated via dispatcher.Dispatch(), etc
 		// must never block.
 
 		buf := scanner.Bytes()
-		numIn.Inc(1)
-
-		key, val, ts, err := m20.ValidatePacket(buf, p.config.Validation_level_legacy.Level, p.config.Validation_level_m20.Level)
-		if err != nil {
-			log.Debug("plain.go: Bad Line: %q", buf)
-			p.bad.Add(key, buf, err)
-			numInvalid.Inc(1)
-			continue
-		}
-
-		if p.config.Validate_order {
-			err = validate.Ordered(key, ts)
-			if err != nil {
-				log.Debug("plain.go: Out of Order Line: %q", buf)
-				p.bad.Add(key, buf, err)
-				numOutOfOrder.Inc(1)
-				continue
-			}
-		}
-
 		log.Debug("plain.go: Received Line: %q", buf)
 
-		p.table.Dispatch(buf, val, ts)
+		p.dispatcher.Dispatch(buf)
 	}
 	if err := scanner.Err(); err != nil {
 		log.Error(err.Error())

--- a/ui/web/web.go
+++ b/ui/web/web.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/graphite-ng/carbon-relay-ng/aggregator"
-	"github.com/graphite-ng/carbon-relay-ng/badmetrics"
 	"github.com/graphite-ng/carbon-relay-ng/cfg"
 	"github.com/graphite-ng/carbon-relay-ng/destination"
 	"github.com/graphite-ng/carbon-relay-ng/rewriter"
@@ -23,7 +22,6 @@ import (
 
 var table *tbl.Table
 var config cfg.Config
-var badMetrics *badmetrics.BadMetrics
 var log = logging.MustGetLogger("ui-web") // for tests. overridden by main
 
 func SetLogger(l *logging.Logger) {
@@ -87,7 +85,7 @@ func badMetricsHandler(w http.ResponseWriter, r *http.Request) (interface{}, *ha
 		return nil, &handlerError{err, "Could not parse timespec", http.StatusBadRequest}
 	}
 
-	records := badMetrics.Get(duration)
+	records := table.Bad().Get(duration)
 	return records, nil
 }
 
@@ -300,10 +298,9 @@ func addRoute(w http.ResponseWriter, r *http.Request) (interface{}, *handlerErro
 	return map[string]string{"Message": "route added"}, nil
 }
 
-func Start(addr string, c cfg.Config, t *tbl.Table, bad *badmetrics.BadMetrics) {
+func Start(addr string, c cfg.Config, t *tbl.Table) {
 	table = t
 	config = c
-	badMetrics = bad
 
 	router := mux.NewRouter()
 	router.Handle("/badMetrics/{timespec}.json", handler(badMetricsHandler)).Methods("GET")


### PR DESCRIPTION
This is a first stab at trying to simplify the input plugins and make them more suitable for using as a library.

It introduces a new `Dispatcher` interface which is implemented by `Table`:
```
type Dispatcher interface {
	Dispatch(buf []byte)
	IncNumIn()
	IncNumInvalid()
}
```

It also moves all the carbon packet validation and badMetrics handling into Table.Dispatch, though incrementing the `numIn` counter remains the responsibility of the input plugin so that it's also possible for the input plugin to increment `numInvalid` (this could be updated so that `IncNumInvalid` increments both underlying counters, in which case `IncNumIn` could be removed and `numIn` incremented in `Dispatch`).