### PR TITLE
make max_procs setting optional, honor GOMAXPROCS env var

### DIFF
--- a/cmd/carbon-relay-ng/carbon-relay-ng.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng.go
@@ -133,9 +133,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	runtime.GOMAXPROCS(config.Max_procs)
-
 	log.Notice("===== carbon-relay-ng instance '%s' starting. (version %s) =====\n", config.Instance, Version)
+
+	if os.Getenv("GOMAXPROCS") == "" && config.Max_procs >= 1 {
+		log.Debug("setting GOMAXPROCS to %d", config.Max_procs)
+		runtime.GOMAXPROCS(config.Max_procs)
+	}
+
 	stats.New(config.Instance)
 
 	if config.Pid_file != "" {

--- a/examples/carbon-relay-ng.ini
+++ b/examples/carbon-relay-ng.ini
@@ -5,7 +5,10 @@
 # supported variables:
 #  ${HOST} : hostname
 instance = "${HOST}"
-max_procs = 2
+
+# this setting can be used to override the default GOMAXPROCS logic
+# it is ignored if the GOMAXPROCS environment variable is set
+# max_procs = 2
 
 admin_addr = "0.0.0.0:2004"
 http_addr = "0.0.0.0:8081"


### PR DESCRIPTION
This isn't needed, the `GOMAXPROCS` env var should be used instead, having this setting means that the `GOMAXPROCS` env var is effectively ignored.