### PR TITLE
alpine moved to a new repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine
+FROM alpine
 RUN apk --update add --no-cache ca-certificates
 ADD carbon-relay-ng /bin/
 VOLUME /conf


### PR DESCRIPTION
gliderlabs has stopped publishing to the old path "gliderlabs/alpine" the new repo is here:
https://hub.docker.com/_/alpine/

This will jump the alpine version from 3.6 (the last published to the old path) to 3.8 but not to "edge"