### PR TITLE
remove logrus dependency from individual packages

### DIFF
--- a/cmd/carbon-relay-ng/carbon-relay-ng.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng.go
@@ -21,12 +21,13 @@ import (
 	"github.com/graphite-ng/carbon-relay-ng/cfg"
 	"github.com/graphite-ng/carbon-relay-ng/input"
 	"github.com/graphite-ng/carbon-relay-ng/input/manager"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	"github.com/graphite-ng/carbon-relay-ng/logger"
 	"github.com/graphite-ng/carbon-relay-ng/stats"
 	tbl "github.com/graphite-ng/carbon-relay-ng/table"
 	"github.com/graphite-ng/carbon-relay-ng/ui/telnet"
 	"github.com/graphite-ng/carbon-relay-ng/ui/web"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"strconv"
 	"strings"
@@ -78,14 +79,18 @@ func main() {
 	}
 	//runtime.SetBlockProfileRate(1) // to enable block profiling. in my experience, adds 35% overhead.
 
+	log.SetLogger(&logger.LogrusLogger{
+		logrus.StandardLogger(),
+	})
+
 	formatter := &logger.TextFormatter{}
 	formatter.TimestampFormat = "2006-01-02 15:04:05.000"
-	log.SetFormatter(formatter)
-	lvl, err := log.ParseLevel(config.Log_level)
+	logrus.SetFormatter(formatter)
+	lvl, err := logrus.ParseLevel(config.Log_level)
 	if err != nil {
 		log.Fatalf("failed to parse log-level %q: %s", config.Log_level, err.Error())
 	}
-	log.SetLevel(lvl)
+	logrus.SetLevel(lvl)
 
 	if *cpuprofile != "" {
 		f, err := os.Create(*cpuprofile)

--- a/cmd/carbon-relay-ng/carbon-relay-ng_test.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/graphite-ng/carbon-relay-ng/cfg"
 	"github.com/graphite-ng/carbon-relay-ng/imperatives"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	tbl "github.com/graphite-ng/carbon-relay-ng/table"
-	log "github.com/sirupsen/logrus"
 )
 
 var packets0A *dummyPackets

--- a/cmd/carbon-relay-ng/testEndpoint_test.go
+++ b/cmd/carbon-relay-ng/testEndpoint_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/Dieterbe/topic"
-	log "github.com/sirupsen/logrus"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 )
 
 // TODO see if we can get simplify this type. do we need to track all bufs? can we do it in a more performant way?

--- a/destination/bufwriter.go
+++ b/destination/bufwriter.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/Dieterbe/go-metrics"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	"github.com/graphite-ng/carbon-relay-ng/stats"
-	log "github.com/sirupsen/logrus"
 )
 
 // Writer implements buffering for an io.Writer object.
@@ -58,7 +58,7 @@ func (b *Writer) flush() error {
 	if b.n == 0 {
 		return nil
 	}
-	if log.IsLevelEnabled(log.TraceLevel) {
+	if log.IsTraceEnabled() {
 		bufs := bytes.Split(b.buf[0:b.n], []byte{'\n'})
 		for _, buf := range bufs {
 			log.Tracef("bufWriter %s flush-writing to tcp %s\n", b.key, buf)

--- a/destination/conn.go
+++ b/destination/conn.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/Dieterbe/go-metrics"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	"github.com/graphite-ng/carbon-relay-ng/stats"
-	log "github.com/sirupsen/logrus"
 )
 
 var keepsafe_initial_cap = 100000 // not very important

--- a/destination/destination.go
+++ b/destination/destination.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	"github.com/Dieterbe/go-metrics"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	"github.com/graphite-ng/carbon-relay-ng/matcher"
 	"github.com/graphite-ng/carbon-relay-ng/stats"
 	"github.com/graphite-ng/carbon-relay-ng/util"
-	log "github.com/sirupsen/logrus"
 )
 
 func addrInstanceSplit(addr string) (string, string) {

--- a/destination/pickle.go
+++ b/destination/pickle.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"encoding/binary"
 
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	"github.com/kisielk/og-rek"
-	log "github.com/sirupsen/logrus"
 )
 
 func Pickle(dp *Datapoint) []byte {

--- a/destination/spool.go
+++ b/destination/spool.go
@@ -4,9 +4,9 @@ import (
 	"time"
 
 	"github.com/Dieterbe/go-metrics"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	"github.com/graphite-ng/carbon-relay-ng/nsqd"
 	"github.com/graphite-ng/carbon-relay-ng/stats"
-	log "github.com/sirupsen/logrus"
 )
 
 // sits in front of nsqd diskqueue.

--- a/input/amqp.go
+++ b/input/amqp.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/graphite-ng/carbon-relay-ng/cfg"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	"github.com/jpillora/backoff"
-	log "github.com/sirupsen/logrus"
 	"github.com/streadway/amqp"
 )
 

--- a/input/listen.go
+++ b/input/listen.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	"github.com/jpillora/backoff"
-	log "github.com/sirupsen/logrus"
 )
 
 // Listener takes care of TCP/UDP networking

--- a/input/manager/manager.go
+++ b/input/manager/manager.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/graphite-ng/carbon-relay-ng/input"
-	log "github.com/sirupsen/logrus"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 )
 
 // Stop shuts down all given input plugins and returns whether it was successfull.

--- a/input/pickle.go
+++ b/input/pickle.go
@@ -9,8 +9,8 @@ import (
 	"io"
 	"math/big"
 
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	ogorek "github.com/kisielk/og-rek"
-	log "github.com/sirupsen/logrus"
 )
 
 type Pickle struct {

--- a/input/plain.go
+++ b/input/plain.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"io"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 )
 
 type Plain struct {

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,238 @@
+package log
+
+type Logger interface {
+	IsTraceEnabled() bool
+
+	Tracef(format string, args ...interface{})
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Printf(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
+	Warningf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Panicf(format string, args ...interface{})
+
+	Trace(args ...interface{})
+	Debug(args ...interface{})
+	Info(args ...interface{})
+	Print(args ...interface{})
+	Warn(args ...interface{})
+	Warning(args ...interface{})
+	Error(args ...interface{})
+	Fatal(args ...interface{})
+	Panic(args ...interface{})
+
+	Traceln(args ...interface{})
+	Debugln(args ...interface{})
+	Infoln(args ...interface{})
+	Println(args ...interface{})
+	Warnln(args ...interface{})
+	Warningln(args ...interface{})
+	Errorln(args ...interface{})
+	Fatalln(args ...interface{})
+	Panicln(args ...interface{})
+}
+
+var std Logger
+
+func SetLogger(logger Logger) {
+	std = logger
+}
+
+// IsTraceEnabled returns true if Trace logging is enabled on the standard logger.
+func IsTraceEnabled() bool {
+	if std == nil {
+		return false
+	}
+	return std.IsTraceEnabled()
+}
+
+// Trace logs a message at level Trace on the standard logger.
+func Trace(args ...interface{}) {
+	if std != nil {
+		std.Trace(args...)
+	}
+}
+
+// Debug logs a message at level Debug on the standard logger.
+func Debug(args ...interface{}) {
+	if std != nil {
+		std.Debug(args...)
+	}
+}
+
+// Print logs a message at level Info on the standard logger.
+func Print(args ...interface{}) {
+	if std != nil {
+		std.Print(args...)
+	}
+}
+
+// Info logs a message at level Info on the standard logger.
+func Info(args ...interface{}) {
+	if std != nil {
+		std.Info(args...)
+	}
+}
+
+// Warn logs a message at level Warn on the standard logger.
+func Warn(args ...interface{}) {
+	if std != nil {
+		std.Warn(args...)
+	}
+}
+
+// Warning logs a message at level Warn on the standard logger.
+func Warning(args ...interface{}) {
+	if std != nil {
+		std.Warning(args...)
+	}
+}
+
+// Error logs a message at level Error on the standard logger.
+func Error(args ...interface{}) {
+	if std != nil {
+		std.Error(args...)
+	}
+}
+
+// Panic logs a message at level Panic on the standard logger.
+func Panic(args ...interface{}) {
+	if std != nil {
+		std.Panic(args...)
+	}
+}
+
+// Fatal logs a message at level Fatal on the standard logger then the process will exit with status set to 1.
+func Fatal(args ...interface{}) {
+	if std != nil {
+		std.Fatal(args...)
+	}
+}
+
+// Tracef logs a message at level Trace on the standard logger.
+func Tracef(format string, args ...interface{}) {
+	if std != nil {
+		std.Tracef(format, args...)
+	}
+}
+
+// Debugf logs a message at level Debug on the standard logger.
+func Debugf(format string, args ...interface{}) {
+	if std != nil {
+		std.Debugf(format, args...)
+	}
+}
+
+// Printf logs a message at level Info on the standard logger.
+func Printf(format string, args ...interface{}) {
+	if std != nil {
+		std.Printf(format, args...)
+	}
+}
+
+// Infof logs a message at level Info on the standard logger.
+func Infof(format string, args ...interface{}) {
+	if std != nil {
+		std.Infof(format, args...)
+	}
+}
+
+// Warnf logs a message at level Warn on the standard logger.
+func Warnf(format string, args ...interface{}) {
+	if std != nil {
+		std.Warnf(format, args...)
+	}
+}
+
+// Warningf logs a message at level Warn on the standard logger.
+func Warningf(format string, args ...interface{}) {
+	if std != nil {
+		std.Warningf(format, args...)
+	}
+}
+
+// Errorf logs a message at level Error on the standard logger.
+func Errorf(format string, args ...interface{}) {
+	if std != nil {
+		std.Errorf(format, args...)
+	}
+}
+
+// Panicf logs a message at level Panic on the standard logger.
+func Panicf(format string, args ...interface{}) {
+	if std != nil {
+		std.Panicf(format, args...)
+	}
+}
+
+// Fatalf logs a message at level Fatal on the standard logger then the process will exit with status set to 1.
+func Fatalf(format string, args ...interface{}) {
+	if std != nil {
+		std.Fatalf(format, args...)
+	}
+}
+
+// Traceln logs a message at level Trace on the standard logger.
+func Traceln(args ...interface{}) {
+	if std != nil {
+		std.Traceln(args...)
+	}
+}
+
+// Debugln logs a message at level Debug on the standard logger.
+func Debugln(args ...interface{}) {
+	if std != nil {
+		std.Debugln(args...)
+	}
+}
+
+// Println logs a message at level Info on the standard logger.
+func Println(args ...interface{}) {
+	if std != nil {
+		std.Println(args...)
+	}
+}
+
+// Infoln logs a message at level Info on the standard logger.
+func Infoln(args ...interface{}) {
+	if std != nil {
+		std.Infoln(args...)
+	}
+}
+
+// Warnln logs a message at level Warn on the standard logger.
+func Warnln(args ...interface{}) {
+	if std != nil {
+		std.Warnln(args...)
+	}
+}
+
+// Warningln logs a message at level Warn on the standard logger.
+func Warningln(args ...interface{}) {
+	if std != nil {
+		std.Warningln(args...)
+	}
+}
+
+// Errorln logs a message at level Error on the standard logger.
+func Errorln(args ...interface{}) {
+	if std != nil {
+		std.Errorln(args...)
+	}
+}
+
+// Panicln logs a message at level Panic on the standard logger.
+func Panicln(args ...interface{}) {
+	if std != nil {
+		std.Panicln(args...)
+	}
+}
+
+// Fatalln logs a message at level Fatal on the standard logger then the process will exit with status set to 1.
+func Fatalln(args ...interface{}) {
+	if std != nil {
+		std.Fatalln(args...)
+	}
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -13,6 +13,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type LogrusLogger struct {
+	*logrus.Logger
+}
+
+func (l *LogrusLogger) IsTraceEnabled() bool {
+	return l.IsLevelEnabled(logrus.TraceLevel)
+}
+
 const defaultTimestampFormat = time.RFC3339
 
 // TextFormatter maintains a list of options to apply while formatting your log output.

--- a/route/cloudwatch.go
+++ b/route/cloudwatch.go
@@ -12,8 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	"github.com/graphite-ng/carbon-relay-ng/stats"
-	log "github.com/sirupsen/logrus"
 	"strconv"
 	"strings"
 )

--- a/route/grafananet.go
+++ b/route/grafananet.go
@@ -15,12 +15,12 @@ import (
 	"github.com/Dieterbe/go-metrics"
 	"github.com/golang/snappy"
 	dest "github.com/graphite-ng/carbon-relay-ng/destination"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	"github.com/graphite-ng/carbon-relay-ng/matcher"
 	"github.com/graphite-ng/carbon-relay-ng/persister"
 	"github.com/graphite-ng/carbon-relay-ng/stats"
 	"github.com/graphite-ng/carbon-relay-ng/util"
 	"github.com/jpillora/backoff"
-	log "github.com/sirupsen/logrus"
 
 	"gopkg.in/raintank/schema.v1"
 	"gopkg.in/raintank/schema.v1/msg"

--- a/route/kafkamdm.go
+++ b/route/kafkamdm.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/Dieterbe/go-metrics"
 	dest "github.com/graphite-ng/carbon-relay-ng/destination"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	"github.com/graphite-ng/carbon-relay-ng/matcher"
 	"github.com/graphite-ng/carbon-relay-ng/stats"
 	"github.com/graphite-ng/carbon-relay-ng/util"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/Shopify/sarama"
 	"github.com/graphite-ng/carbon-relay-ng/persister"

--- a/route/pubsub.go
+++ b/route/pubsub.go
@@ -13,9 +13,9 @@ import (
 	"cloud.google.com/go/pubsub"
 	"github.com/Dieterbe/go-metrics"
 	dest "github.com/graphite-ng/carbon-relay-ng/destination"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	"github.com/graphite-ng/carbon-relay-ng/matcher"
 	"github.com/graphite-ng/carbon-relay-ng/stats"
-	log "github.com/sirupsen/logrus"
 )
 
 // gzipPool provides a sync.Pool of initialized gzip.Writer's to avoid

--- a/route/route.go
+++ b/route/route.go
@@ -7,8 +7,8 @@ import (
 	"sync/atomic"
 
 	dest "github.com/graphite-ng/carbon-relay-ng/destination"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	"github.com/graphite-ng/carbon-relay-ng/matcher"
-	log "github.com/sirupsen/logrus"
 )
 
 type Config interface {

--- a/table/table.go
+++ b/table/table.go
@@ -14,13 +14,13 @@ import (
 	"github.com/graphite-ng/carbon-relay-ng/badmetrics"
 	"github.com/graphite-ng/carbon-relay-ng/cfg"
 	"github.com/graphite-ng/carbon-relay-ng/imperatives"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	"github.com/graphite-ng/carbon-relay-ng/matcher"
 	"github.com/graphite-ng/carbon-relay-ng/rewriter"
 	"github.com/graphite-ng/carbon-relay-ng/route"
 	"github.com/graphite-ng/carbon-relay-ng/stats"
 	"github.com/graphite-ng/carbon-relay-ng/validate"
 	m20 "github.com/metrics20/go-metrics20/carbon20"
-	log "github.com/sirupsen/logrus"
 )
 
 type TableConfig struct {

--- a/ui/telnet/telnet.go
+++ b/ui/telnet/telnet.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	"github.com/graphite-ng/carbon-relay-ng/imperatives"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	tbl "github.com/graphite-ng/carbon-relay-ng/table"
 	"github.com/graphite-ng/carbon-relay-ng/telnet"
-	log "github.com/sirupsen/logrus"
 )
 
 var table *tbl.Table

--- a/ui/web/web.go
+++ b/ui/web/web.go
@@ -14,10 +14,10 @@ import (
 	"github.com/graphite-ng/carbon-relay-ng/aggregator"
 	"github.com/graphite-ng/carbon-relay-ng/cfg"
 	"github.com/graphite-ng/carbon-relay-ng/destination"
+	"github.com/graphite-ng/carbon-relay-ng/log"
 	"github.com/graphite-ng/carbon-relay-ng/rewriter"
 	"github.com/graphite-ng/carbon-relay-ng/route"
 	tbl "github.com/graphite-ng/carbon-relay-ng/table"
-	log "github.com/sirupsen/logrus"
 )
 
 var table *tbl.Table


### PR DESCRIPTION
This PR demonstrates some ideas I had of how to remove the tie between the individual packages in the project and the log library, so that they could be used by projects that use a different logging library.

This is done by creating a new `log` package that declares a `Logger` interface and provides functions to be used for logging within `carbon-relay-ng` along with a function to inject a `Logger`.  All packages in the project that need to create log entries use this package.

The `logger` package is now just responsible for creation of the `Logger`, and is used by `cmd/carbon-relay-ng` to inject the `Logger` into `log` at startup.  It defines a new `LogrusLogger` type, which is responsible for embedding a `logrus.Logger` and fulfilling the `Logger` interface.