### PR TITLE
support new tsdbgw response with detailed info about invalid metrics

### DIFF
--- a/route/grafananet.go
+++ b/route/grafananet.go
@@ -260,7 +260,7 @@ func (route *GrafanaNet) flush(mda schema.MetricDataArray, req *http.Request) (t
 			var b strings.Builder
 			fmt.Fprintf(&b, "request contained %d invalid metrics that were dropped (%d valid metrics were published in this request)\n", resp.Invalid, resp.Published)
 			for key, vErr := range resp.ValidationErrors {
-				fmt.Fprintf(&b, "%q : %d metrics.  Examples:\n", key, vErr.Count)
+				fmt.Fprintf(&b, "  %q : %d metrics.  Examples:\n", key, vErr.Count)
 				for _, idx := range vErr.ExampleIds {
 					fmt.Fprintf(&b, "   - %#v\n", mda[idx])
 				}

--- a/route/grafananet.go
+++ b/route/grafananet.go
@@ -262,7 +262,7 @@ func (route *GrafanaNet) flush(mda schema.MetricDataArray, req *http.Request) (t
 			for key, vErr := range resp.ValidationErrors {
 				fmt.Fprintf(&b, "%q : %d metrics.  Examples:\n", key, vErr.Count)
 				for _, idx := range vErr.ExampleIds {
-					fmt.Fprintf(&b, "%#v\n", mda[idx])
+					fmt.Fprintf(&b, "   - %#v\n", mda[idx])
 				}
 			}
 			log.Warn(b.String())

--- a/route/grafananet_response.go
+++ b/route/grafananet_response.go
@@ -1,0 +1,12 @@
+package route
+
+type MetricsResponse struct {
+	Invalid          int
+	Published        int
+	ValidationErrors map[string]ValidationError
+}
+
+type ValidationError struct {
+	Count      int
+	ExampleIds []int
+}


### PR DESCRIPTION
this should only be merged once https://github.com/raintank/tsdb-gw/pull/144 is merged and deployed to all our instances/clusters.

to test:
1) check out that tsdb-gw version, run `make` and `scripts/build_docker.sh` in the tsdbgw directory
2) you can use metrictank's docker stack, docker/docker-dev-custom-cfg-kafka/ but apply this change:
```
-    image: raintank/tsdb-gw:0.9.0
+    image: raintank/tsdb-gw:latest
```
3 ) using this branch, and after running `make`, run carbon-relay-ng with this config: https://gist.github.com/Dieterbe/2bdc5834a248b75df64377a70cb380d1

the important bits are disabling validation, reduced concurrency to have fewer requests with multiple points, and having the grafanaNet route for tsdbgw

you can then do this:
```
~ ❯❯❯ cat test.txt
my.series1;tag1=value1;tag2=value2 1 1
my.series2;tag1;value1;tag2=value2 1 1
my.series3;tag1=value1;tag2=value2 1 1
~ ❯❯❯ cat test.txt | nc localhost 2013
~ ❯❯❯ 
```
and will see:
```
2019-01-09 13:14:17.199 [WARNING] request contained 1 invalid metrics that were dropped (2 valid metrics were published in this request)
"invalid tag format" : 1 metrics.  Examples:
&schema.MetricData{Id:"1.6fb4b35dfce5647ed4758fcae062dc9a", OrgId:1, Name:"my.series2", Metric:"my.series2", Interval:10, Value:1, Unit:"unknown", Time:1, Mtype:"gauge", Tags:[]string{"tag1", "tag2=value2", "value1"}}
```