### PR TITLE
support pickle protocol versions 0, 1, 2, 3 & 4 + accept pickle arrays + send pickle tuples

### DIFF
--- a/destination/pickle.go
+++ b/destination/pickle.go
@@ -4,16 +4,16 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/kisielk/og-rek"
+	ogorek "github.com/kisielk/og-rek"
 	log "github.com/sirupsen/logrus"
 )
 
 func Pickle(dp *Datapoint) []byte {
 	dataBuf := &bytes.Buffer{}
-	pickler := ogórek.NewEncoder(dataBuf)
+	pickler := ogorek.NewEncoder(dataBuf)
 
 	// pickle format (in python talk): [(path, (timestamp, value)), ...]
-	point := []interface{}{string(dp.Name), []interface{}{dp.Time, dp.Val}}
+	point := ogorek.Tuple{string(dp.Name), ogorek.Tuple{dp.Time, dp.Val}}
 	list := []interface{}{point}
 	pickler.Encode(list)
 	messageBuf := &bytes.Buffer{}

--- a/input/pickle.go
+++ b/input/pickle.go
@@ -124,12 +124,18 @@ func (p *Pickle) Handle(c io.Reader) error {
 	ItemLoop:
 		for _, rawItem := range decoded {
 			log.Debug("pickle.go: doing high-level validation of unpickled item and data...")
-			item, ok := rawItem.(ogorek.Tuple)
-			if !ok {
+			var item []interface{}
+			switch v := rawItem.(type) {
+			case ogorek.Tuple:
+				item = []interface{}(v)
+			case []interface{}:
+				item = v
+			default:
 				log.Errorf("pickle.go: Unrecognized type %T for item", rawItem)
 				p.dispatcher.IncNumInvalid()
-				continue
+				continue ItemLoop
 			}
+
 			if len(item) != 2 {
 				log.Errorf("pickle.go: item length must be 2, got %d", len(item))
 				p.dispatcher.IncNumInvalid()
@@ -143,12 +149,18 @@ func (p *Pickle) Handle(c io.Reader) error {
 				continue
 			}
 
-			data, ok := item[1].(ogorek.Tuple)
-			if !ok {
-				log.Errorf("pickle.go: item data must be an array, got %T", item[1])
+			var data []interface{}
+			switch v := item[1].(type) {
+			case ogorek.Tuple:
+				data = []interface{}(v)
+			case []interface{}:
+				data = v
+			default:
+				log.Errorf("pickle.go: item data must be a tuple, got %T", item[1])
 				p.dispatcher.IncNumInvalid()
-				continue
+				continue ItemLoop
 			}
+
 			if len(data) != 2 {
 				log.Errorf("pickle.go: item data length must be 2, got %d", len(data))
 				p.dispatcher.IncNumInvalid()

--- a/input/pickle.go
+++ b/input/pickle.go
@@ -60,8 +60,17 @@ func (p *Pickle) Handle(c io.Reader) error {
 			return fmt.Errorf("couldn't read payload prefix: %s", err.Error())
 		}
 
-		// payload must start with opProto, <version>, opEmptyList
-		if prefix[0] != '\x80' || prefix[2] != ']' {
+		// payload must start with:
+		switch true {
+		// version 4 - opProto, <version>, opFrame
+		case prefix[0] == '\x80' && prefix[2] == '\x95':
+		// version 2, 3 - opProto, <version>, opEmptyList
+		case prefix[0] == '\x80' && prefix[2] == ']':
+		// version 1 - opEmptyList
+		case prefix[0] == ']':
+		// version 0 - opMark, opList
+		case prefix[0] == '(' && prefix[1] == 'l':
+		default:
 			return errors.New("invalid payload prefix")
 		}
 


### PR DESCRIPTION
Fixes #340 

We have this check in place to drop obviosuly-invalid data sent to the pickle port, rather than trying to feed it into og-rek.

With this update we should cover all possible valid payload prefixes for pickle protocol versions 0 through 4.

To verify, you can send a test metric with a command like:
```
python -c 'import pickle, struct, os; payload = pickle.dumps([("metric",(1,2))],protocol=2); os.write(1, struct.pack("!L", len(payload)) + payload)' | nc localhost 2014
```
Replace `protocol=2` to test other supported versions, to use protocol 3 or 4 you need to be running python 3.x