### PR TITLE
fix different connections to same host:port using same spool file

### DIFF
--- a/destination/destination.go
+++ b/destination/destination.go
@@ -74,8 +74,8 @@ func New(routeName, prefix, sub, regex, addr, spoolDir string, spool, pickle boo
 	if err != nil {
 		return nil, err
 	}
-	addr, instance := addrInstanceSplit(addr)
 	key := util.Key(routeName, addr)
+	addr, instance := addrInstanceSplit(addr)
 	dest := &Destination{
 		Matcher:              *m,
 		Addr:                 addr,


### PR DESCRIPTION
 -this solve the issue of key overlapping when two destinations
  use the same ip:port; that issue was causing different
  connections to use the same spool file.

Signed-off-by: Jean-Francois Weber-Marx <jfwm@hotmail.com>