### PR TITLE
Use $(CURDIR) instead of $(pwd) in Makefile's run-docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ run: build
 	./carbon-relay-ng carbon-relay-ng.ini
 
 run-docker:
-	docker run --rm -p 2003:2003 -p 2004:2004 -p 8081:8081 -v $(pwd)/examples:/conf -v $(pwd)/spool:/spool raintank/carbon-relay-ng
+	docker run --rm -p 2003:2003 -p 2004:2004 -p 8081:8081 -v $(CURDIR)/examples:/conf -v $(CURDIR)/spool:/spool raintank/carbon-relay-ng
 
 clean:
 	rm -f carbon-relay-ng carbon-relay-ng.exe


### PR DESCRIPTION
It a variable provided by GNU's make, which has two benefits:
- No need for a shell expand
- Compatible with all shells
