### PR TITLE
bugfix: allow partitionBy bySeriesWithTags

### DIFF
--- a/imperatives/imperatives.go
+++ b/imperatives/imperatives.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/metrictank/cluster/partitioner"
 	"github.com/graphite-ng/carbon-relay-ng/aggregator"
 	"github.com/graphite-ng/carbon-relay-ng/destination"
 	"github.com/graphite-ng/carbon-relay-ng/matcher"
@@ -592,7 +593,8 @@ func readAddRouteKafkaMdm(s *toki.Scanner, table Table) error {
 		return errFmtAddRouteKafkaMdm
 	}
 	partitionBy := string(t.Value)
-	if partitionBy != "byOrg" && partitionBy != "bySeries" {
+	_, err = partitioner.NewKafka(partitionBy)
+	if err != nil {
 		return errFmtAddRouteKafkaMdm
 	}
 

--- a/table/table.go
+++ b/table/table.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/Dieterbe/go-metrics"
+	"github.com/grafana/metrictank/cluster/partitioner"
 	"github.com/graphite-ng/carbon-relay-ng/aggregator"
 	"github.com/graphite-ng/carbon-relay-ng/badmetrics"
 	"github.com/graphite-ng/carbon-relay-ng/cfg"
@@ -768,8 +769,9 @@ func (table *Table) InitRoutes(config cfg.Config, meta toml.MetaData) error {
 			var timeout = 2000      // in ms
 			var orgId = 1
 
-			if routeConfig.PartitionBy != "byOrg" && routeConfig.PartitionBy != "bySeries" {
-				return fmt.Errorf("invalid partitionBy for route '%s'", routeConfig.Key)
+			_, err := partitioner.NewKafka(routeConfig.PartitionBy)
+			if err != nil {
+				return fmt.Errorf("config error for route '%s': %s", routeConfig.Key, err.Error())
 			}
 
 			if routeConfig.BufSize != 0 {


### PR DESCRIPTION
by just relying on partitioner.NewKafka() for validation, instead of
implementing validation in 3 different places.