### PR TITLE
Aggregation point tracker

### DIFF
--- a/aggregator/aggregator_reporter.go
+++ b/aggregator/aggregator_reporter.go
@@ -1,0 +1,48 @@
+package aggregator
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/graphite-ng/carbon-relay-ng/statsmt"
+)
+
+// AggregatorReporter reports the state of aggregation buckets when they are known. (after flushing)
+// it reports on buckets by their logical timestamps, not wallclock time
+type AggregatorReporter struct {
+	sync.Mutex
+	buf []aggregate
+}
+
+type aggregate struct {
+	key   string
+	ts    uint32
+	count uint32
+}
+
+func NewAggregatorReporter() (*AggregatorReporter, error) {
+	p := AggregatorReporter{}
+	aggregatorReporter = &p
+	return statsmt.Register.GetOrAdd("aggregator", &p).(*AggregatorReporter), nil
+}
+
+func (r *AggregatorReporter) add(key string, ts, count uint32) {
+	r.Lock()
+	r.buf = append(r.buf, aggregate{
+		key:   key,
+		ts:    ts,
+		count: count,
+	})
+	r.Unlock()
+}
+func (r *AggregatorReporter) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+	r.Lock()
+	for _, a := range r.buf {
+		buf = statsmt.WriteUint64(buf, prefix, []byte(fmt.Sprintf("aggregator.%s.in_logical", a.key)), uint64(a.count), time.Unix(int64(a.ts), 0))
+	}
+	r.buf = r.buf[:0]
+	r.Unlock()
+
+	return buf
+}

--- a/aggregator/init.go
+++ b/aggregator/init.go
@@ -15,6 +15,8 @@ var rangeTracker *RangeTracker
 var flushes = util.NewLimiter(1)
 var flushWaiting = stats.Gauge("unit=aggregator.what=flush_waiting")
 
+var aggregatorReporter *AggregatorReporter
+
 func InitMetrics() {
 	numTooOld = stats.Counter("module=aggregator.unit=Metric.what=TooOld")
 	rangeTracker = NewRangeTracker()

--- a/cmd/carbon-relay-ng/carbon-relay-ng.go
+++ b/cmd/carbon-relay-ng/carbon-relay-ng.go
@@ -155,6 +155,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("stats: could not initialize process reporter: %v", err)
 		}
+		aggregator.NewAggregatorReporter()
 		statsmt.NewGraphite("carbon-relay-ng.stats."+config.Instance, config.Instrumentation.Graphite_addr, config.Instrumentation.Graphite_interval/1000, 1000, time.Second*10)
 	}
 

--- a/statsmt/bool.go
+++ b/statsmt/bool.go
@@ -10,7 +10,7 @@ type Bool struct {
 }
 
 func NewBool(name string) *Bool {
-	return registry.getOrAdd(name, &Bool{}).(*Bool)
+	return Register.GetOrAdd(name, &Bool{}).(*Bool)
 }
 
 func (b *Bool) SetTrue() {

--- a/statsmt/counter32.go
+++ b/statsmt/counter32.go
@@ -10,7 +10,7 @@ type Counter32 struct {
 }
 
 func NewCounter32(name string) *Counter32 {
-	return registry.getOrAdd(name, &Counter32{}).(*Counter32)
+	return Register.GetOrAdd(name, &Counter32{}).(*Counter32)
 }
 
 func (c *Counter32) SetUint32(val uint32) {

--- a/statsmt/counter64.go
+++ b/statsmt/counter64.go
@@ -10,7 +10,7 @@ type Counter64 struct {
 }
 
 func NewCounter64(name string) *Counter64 {
-	return registry.getOrAdd(name, &Counter64{}).(*Counter64)
+	return Register.GetOrAdd(name, &Counter64{}).(*Counter64)
 }
 
 func (c *Counter64) SetUint64(val uint64) {

--- a/statsmt/counterrate32.go
+++ b/statsmt/counterrate32.go
@@ -16,7 +16,7 @@ func NewCounterRate32(name string) *CounterRate32 {
 	c := CounterRate32{
 		since: time.Now(),
 	}
-	return registry.getOrAdd(name, &c).(*CounterRate32)
+	return Register.GetOrAdd(name, &c).(*CounterRate32)
 }
 
 func (c *CounterRate32) SetUint32(val uint32) {

--- a/statsmt/gauge32.go
+++ b/statsmt/gauge32.go
@@ -10,7 +10,7 @@ type Gauge32 struct {
 }
 
 func NewGauge32(name string) *Gauge32 {
-	return registry.getOrAdd(name, &Gauge32{}).(*Gauge32)
+	return Register.GetOrAdd(name, &Gauge32{}).(*Gauge32)
 }
 
 func (g *Gauge32) Inc() {

--- a/statsmt/gauge64.go
+++ b/statsmt/gauge64.go
@@ -9,7 +9,7 @@ type Gauge64 uint64
 
 func NewGauge64(name string) *Gauge64 {
 	u := Gauge64(0)
-	return registry.getOrAdd(name, &u).(*Gauge64)
+	return Register.GetOrAdd(name, &u).(*Gauge64)
 }
 
 func (g *Gauge64) Inc() {

--- a/statsmt/init.go
+++ b/statsmt/init.go
@@ -9,12 +9,12 @@
 // Currently supported outputs are DevNull and Graphite
 package statsmt
 
-var registry *Registry
+var Register *Registry
 
 func init() {
-	registry = NewRegistry()
+	Register = NewRegistry()
 }
 
 func Clear() {
-	registry.Clear()
+	Register.Clear()
 }

--- a/statsmt/kafka.go
+++ b/statsmt/kafka.go
@@ -22,8 +22,8 @@ type KafkaPartition struct {
 
 func NewKafkaPartition(prefix string) *KafkaPartition {
 	k := KafkaPartition{}
-	registry.getOrAdd(prefix+".offset", &k.Offset)
-	registry.getOrAdd(prefix+".log_size", &k.LogSize)
-	registry.getOrAdd(prefix+".lag", &k.Lag)
+	Register.GetOrAdd(prefix+".offset", &k.Offset)
+	Register.GetOrAdd(prefix+".log_size", &k.LogSize)
+	Register.GetOrAdd(prefix+".lag", &k.Lag)
 	return &k
 }

--- a/statsmt/latencyhistogram12h32.go
+++ b/statsmt/latencyhistogram12h32.go
@@ -13,7 +13,7 @@ type LatencyHistogram12h32 struct {
 }
 
 func NewLatencyHistogram12h32(name string) *LatencyHistogram12h32 {
-	return registry.getOrAdd(name, &LatencyHistogram12h32{
+	return Register.GetOrAdd(name, &LatencyHistogram12h32{
 		hist:  hist12h.New(),
 		since: time.Now(),
 	},

--- a/statsmt/latencyhistogram15s32.go
+++ b/statsmt/latencyhistogram15s32.go
@@ -15,7 +15,7 @@ type LatencyHistogram15s32 struct {
 }
 
 func NewLatencyHistogram15s32(name string) *LatencyHistogram15s32 {
-	return registry.getOrAdd(name, &LatencyHistogram15s32{
+	return Register.GetOrAdd(name, &LatencyHistogram15s32{
 		hist:  hist15s.New(),
 		since: time.Now(),
 	},

--- a/statsmt/memory_reporter.go
+++ b/statsmt/memory_reporter.go
@@ -15,7 +15,7 @@ type MemoryReporter struct {
 }
 
 func NewMemoryReporter() *MemoryReporter {
-	return registry.getOrAdd("memory", &MemoryReporter{}).(*MemoryReporter)
+	return Register.GetOrAdd("memory", &MemoryReporter{}).(*MemoryReporter)
 }
 
 func getGcPercent() int {

--- a/statsmt/meter32.go
+++ b/statsmt/meter32.go
@@ -26,7 +26,7 @@ type Meter32 struct {
 }
 
 func NewMeter32(name string, approx bool) *Meter32 {
-	return registry.getOrAdd(name, &Meter32{
+	return Register.GetOrAdd(name, &Meter32{
 		approx: approx,
 		hist:   make(map[uint32]uint32),
 		min:    math.MaxUint32,

--- a/statsmt/out_devnull.go
+++ b/statsmt/out_devnull.go
@@ -9,7 +9,7 @@ func NewDevnull() {
 		ticker := tick(time.Second)
 		buf := make([]byte, 0)
 		for now := range ticker {
-			for _, metric := range registry.list() {
+			for _, metric := range Register.List() {
 				metric.ReportGraphite(nil, buf[:], now)
 			}
 		}

--- a/statsmt/out_graphite.go
+++ b/statsmt/out_graphite.go
@@ -68,7 +68,7 @@ func (g *Graphite) reporter(interval int) {
 		buf := make([]byte, 0)
 
 		var fullPrefix bytes.Buffer
-		for name, metric := range registry.list() {
+		for name, metric := range Register.List() {
 			fullPrefix.Reset()
 			fullPrefix.Write(g.prefix)
 			fullPrefix.WriteString(name)

--- a/statsmt/process_reporter.go
+++ b/statsmt/process_reporter.go
@@ -20,7 +20,7 @@ func NewProcessReporter() (*ProcessReporter, error) {
 	if err != nil {
 		return nil, err
 	}
-	return registry.getOrAdd("process", &p).(*ProcessReporter), nil
+	return Register.GetOrAdd("process", &p).(*ProcessReporter), nil
 }
 
 func (m *ProcessReporter) ReportGraphite(prefix, buf []byte, now time.Time) []byte {

--- a/statsmt/range32.go
+++ b/statsmt/range32.go
@@ -19,7 +19,7 @@ type Range32 struct {
 }
 
 func NewRange32(name string) *Range32 {
-	return registry.getOrAdd(name, &Range32{
+	return Register.GetOrAdd(name, &Range32{
 		min: math.MaxUint32,
 	},
 	).(*Range32)

--- a/statsmt/registry.go
+++ b/statsmt/registry.go
@@ -24,7 +24,7 @@ func NewRegistry() *Registry {
 	}
 }
 
-func (r *Registry) getOrAdd(name string, metric GraphiteMetric) GraphiteMetric {
+func (r *Registry) GetOrAdd(name string, metric GraphiteMetric) GraphiteMetric {
 	r.Lock()
 	if existing, ok := r.metrics[name]; ok {
 		if reflect.TypeOf(existing) == reflect.TypeOf(metric) {
@@ -38,7 +38,7 @@ func (r *Registry) getOrAdd(name string, metric GraphiteMetric) GraphiteMetric {
 	return metric
 }
 
-func (r *Registry) list() map[string]GraphiteMetric {
+func (r *Registry) List() map[string]GraphiteMetric {
 	metrics := make(map[string]GraphiteMetric)
 	r.Lock()
 	for name, metric := range r.metrics {

--- a/statsmt/timediff_reporter.go
+++ b/statsmt/timediff_reporter.go
@@ -12,7 +12,7 @@ type TimeDiffReporter32 struct {
 }
 
 func NewTimeDiffReporter32(name string, target uint32) *TimeDiffReporter32 {
-	return registry.getOrAdd(name, &TimeDiffReporter32{
+	return Register.GetOrAdd(name, &TimeDiffReporter32{
 		target: target,
 	},
 	).(*TimeDiffReporter32)


### PR DESCRIPTION
Here's a demo of how to use this:

first of all, you'll need to know the key(s) for your configured aggregator(s).
they are shown on the admin web UI and also printed at startup

then, start the relay with this config:
(basic config with 1 aggregator)
```
cat experiments/carbon-relay-ng.ini.dev-nc
## Global settings ##

# instance id's distinguish stats of multiple relays.
# do not run multiple relays with the same instance id.
# supported variables:
#  ${HOST} : hostname
instance = "${HOST}"
max_procs = 2

admin_addr = "0.0.0.0:2004"
http_addr = "0.0.0.0:8081"
spool_dir = "./carbon-relay-ng"
pid_file = "./carbon-relay-ng.pid"
## Logging ##
# one of critical error warning notice info debug
# see docs/logging.md for level descriptions
log_level = "info"

## Validation of inputs ##
# Metric name validation strictness for legacy metrics. Valid values are:
# strict - Block anything that can upset graphite: valid characters are [A-Za-z0-9_-.]; consecutive dots are not allowed
# medium - Valid characters are ASCII; no embedded NULLs
# none   - No validation is performed
validation_level_legacy = "medium"
# Metric validation for carbon2.0 (metrics2.0) metrics.
# Metrics that contain = or _is_ are assumed carbon2.0.
# Valid values are:
# medium - checks for unit and mtype tag, presence of another tag, and constency (use = or _is_, not both)
# none   - No validation is performed
validation_level_m20 = "medium"

# you can also validate that each series has increasing timestamps
validate_order = false

# How long to keep track of invalid metrics seen
# Useful time units are "s", "m", "h"
bad_metrics_max_age = "24h"

# Blacklist
# See https://github.com/graphite-ng/carbon-relay-ng/blob/master/docs/config.md#Blacklist

blacklist = [
]

## Inputs ##

### plaintext Carbon ###
listen_addr = "0.0.0.0:2013"
# close inbound plaintext connections if they've been idle for this long ("0s" to disable)
#plain_read_timeout = "2m"

### Pickle Carbon ###
pickle_addr = "0.0.0.0:2023"
# close inbound pickle connections if they've been idle for this long ("0s" to disable)
pickle_read_timeout = "2m"

### AMQP ###
[amqp]
amqp_enabled = false
amqp_host = "localhost"
amqp_port = 5672
amqp_user = "guest"
amqp_password = "guest"
amqp_vhost = "/graphite"
amqp_exchange = "metrics"
amqp_queue = ""
amqp_key = "#"
amqp_durable = false
amqp_exclusive = true

# Aggregators
# See https://github.com/graphite-ng/carbon-relay-ng/blob/master/docs/config.md#Aggregators

[[aggregation]]
# aggregate timer metrics with sums
function = 'sum'
prefix = ''
substr = ''
regex = '^foo\.(.*)'
format = 'sum_foo.$1.'
interval = 10
wait = 20

# Rewriters
# See https://github.com/graphite-ng/carbon-relay-ng/blob/master/docs/config.md#Rewriters

# Routes
# See https://github.com/graphite-ng/carbon-relay-ng/blob/master/docs/config.md#Routes
[[route]]
# a plain carbon route that sends all data to the specified carbon (graphite) server
key = 'carbon-default'
type = 'sendAllMatch'
# prefix = ''
# substr = ''
# regex = ''
destinations = [
  '127.0.0.1:2003 spool=false pickle=false'
]

[init]
# init commands (DEPRECATED)
# see https://github.com/graphite-ng/carbon-relay-ng/blob/master/docs/config.md#Imperatives
cmds = [
]

## Instrumentation ##

[instrumentation]
# in addition to serving internal metrics via expvar, you can send them to graphite/carbon
# IMPORTANT: setting this to "" will disable flushing, and metrics will pile up and lead to OOM
# see https://github.com/graphite-ng/carbon-relay-ng/issues/50
# so for now you MUST send them somewhere. sorry.
# (Also, the interval here must correspond to your setting in storage-schemas.conf if you use grafana hosted metrics)
graphite_addr = "localhost:2013"
graphite_interval = 1000  # in ms
```

then we run `while sleep 1; do echo "wallclock now $(date +%s)"; done & nc -l -p 2003 | egrep '49cd9cc|foo'` which will give us all outbound metrics related to the aggregator, interspersed with realtime clock updates.
Then we simply run this:

```
echo "foo.bar 123 $(($(date +%s)-12))\nfoo.bar 123 $(date +%s)\nfoo.bar 123 $(($(date +%s)-15))" | nc  localhost 2013
```

this sends 3 points all at once, but 2 of them fall into an older bucket that the relay would be waiting for.

here's the output:
```
~ ❯❯❯ while sleep 1; do echo "wallclock now $(date +%s)"; done & nc -l -p 2003 | egrep '49cd9cc|foo'                                                                                         ⏎
[1] 1137077
wallclock now 1573669377
wallclock now 1573669378
wallclock now 1573669379
wallclock now 1573669380
wallclock now 1573669381
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 0 1573669381
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 0 1573669381
wallclock now 1573669382
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 0 1573669382
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 0 1573669382
wallclock now 1573669383
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 0 1573669383
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 0 1573669383
wallclock now 1573669384
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 0 1573669384
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 0 1573669384
wallclock now 1573669385
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 0 1573669385
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 0 1573669385
wallclock now 1573669386
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 0 1573669386
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 0 1573669386
wallclock now 1573669387
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 0 1573669387
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 0 1573669387
wallclock now 1573669388
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 0 1573669388
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 0 1573669388
wallclock now 1573669389
foo.bar 123 1573669376
foo.bar 123 1573669388
foo.bar 123 1573669373
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 0 1573669389
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669389
wallclock now 1573669390
sum_foo.bar. 246.000000 1573669370
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669390
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 1 1573669390
wallclock now 1573669391
carbon-relay-ng.stats.dieter-m6800.aggregator.aggregator.49cd9cc.in_logical 2 1573669370
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 1 1573669391
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669391
wallclock now 1573669392
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669392
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 1 1573669392
wallclock now 1573669393
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669393
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 1 1573669393
wallclock now 1573669394
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669394
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 1 1573669394
wallclock now 1573669395
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669395
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 1 1573669395
wallclock now 1573669396
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 1 1573669396
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669396
wallclock now 1573669397
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669397
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 1 1573669397
wallclock now 1573669398
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 1 1573669398
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669398
wallclock now 1573669399
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 1 1573669399
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669399
wallclock now 1573669400
sum_foo.bar. 123.000000 1573669380
carbon-relay-ng.stats.dieter-m6800.aggregator.aggregator.49cd9cc.in_logical 1 1573669380
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669400
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669400
wallclock now 1573669401
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669401
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669401
wallclock now 1573669402
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669402
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669402
wallclock now 1573669403
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669403
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669403
wallclock now 1573669404
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669404
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669404
wallclock now 1573669405
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669405
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669405
wallclock now 1573669406
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669406
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669406
wallclock now 1573669407
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669407
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669407
wallclock now 1573669408
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669408
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669408
wallclock now 1573669409
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669409
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669409
wallclock now 1573669410
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669410
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669410
wallclock now 1573669411
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669411
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669411
wallclock now 1573669412
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669412
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669412
wallclock now 1573669413
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669413
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669413
wallclock now 1573669414
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669414
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669414
wallclock now 1573669415
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669415
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669415
wallclock now 1573669416
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669416
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669416
wallclock now 1573669417
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669417
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669417
wallclock now 1573669418
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669418
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669418
wallclock now 1573669419
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669419
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669419
wallclock now 1573669420
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669420
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669420
wallclock now 1573669421
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669421
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669421
wallclock now 1573669422
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_in.aggregator_is_49cd9cc 3 1573669422
service_is_carbon-relay-ng.instance_is_dieter-m6800.mtype_is_counter.unit_is_Metric.direction_is_out.aggregator_is_49cd9cc 2 1573669422
```

the key takeaways here are:
1) the direction_in counter simply increments for any input points seen (so it increments to 3 at whatever time the metrics were sent)
2) the direction_out counter simply increments whenever we flush a bucket (e.g. for each "sum_foo.bar" output point)
3) the new metric, `carbon-relay-ng.stats.dieter-m6800.aggregator.aggregator.49cd9cc.in_logical` reports the bucket counts with the timestamp of the actual buckets. we see this in action: every time the wall clock hits a round timestamp, the 20s wait is over and it flushes the 20s old bucket, at which point it also flushes the new count for that metric.